### PR TITLE
chore(gh-149): remove deleted id selector

### DIFF
--- a/source/_imports/objects/o-section.css
+++ b/source/_imports/objects/o-section.css
@@ -265,7 +265,6 @@ Styleguide Objects.Section
 [class*="o-section--style"] { z-index: 1; }
 
 /* HACK: To hide `.o-section__banner-image` overflow */
-main /* SEE: https://github.com/TACC/Core-CMS/pull/151 */,
-#content-wrap /* HACK: Using ID selector until <main> exists */ {
+main {
   overflow-x: hidden;
 }


### PR DESCRIPTION
## Overview

Remove legacy selectors.

## Related

- requires https://github.com/TACC/Core-CMS/pull/151
- mirrors https://github.com/TACC/Core-CMS-Resources/pull/133

## Changes

- Delete legacy part of CSS selectors.