### PR TITLE
feat(gh-99): use pixel for standard space props

### DIFF
--- a/source/_imports/settings/props.space.css
+++ b/source/_imports/settings/props.space.css
@@ -23,12 +23,15 @@ Styleguide Settings.CustomProperties.Space
     --(…)large: larger value
 */
 :root {
-  --global-space--xx-small: 0.125rem;  /*  2px (if base is 16px) */
-  --global-space--x-small: 0.25rem;    /*  4px (if base is 16px) */
-  --global-space--small: 0.5rem;       /*  8px (if base is 16px) */
-  --global-space--normal: 1.0rem;      /* 16px (if base is 16px) */
-  --global-space--large: 1.5rem;       /* 25px (if base is 16px) */
-  --global-space--x-large: 3.0rem;     /* 48px (if base is 16px) */
+  /* Sample Standards */
+  /*
+  --global-space--xx-small: 2px; /* 0.125rem at base font 16px *\/
+  --global-space--x-small:  4px; /* 0.25rem at base font 16px *\/
+  --global-space--small:    8px; /* 0.5rem at base font 16px *\/
+  --global-space--normal:  16px; /* 1.0rem at base font 16px *\/
+  --global-space--large:   24px; /* 1.5rem at base font 16px *\/
+  --global-space--x-large: 48px; /* 3.0rem at base font 16px *\/
+  */
 
   --global-space--list-indent: 40px;   /* browser default (Firefox, Edge) */
   --global-space--grid-gap: 15px;      /* Bootstrap `.container` & `.row` */

--- a/source/_imports/settings/props.space.css
+++ b/source/_imports/settings/props.space.css
@@ -23,15 +23,12 @@ Styleguide Settings.CustomProperties.Space
     --(…)large: larger value
 */
 :root {
-  /* Sample Standards */
-  /*
-  --global-space--xx-small: 2px; /* 0.125rem at base font 16px *\/
-  --global-space--x-small:  4px; /* 0.25rem at base font 16px *\/
-  --global-space--small:    8px; /* 0.5rem at base font 16px *\/
-  --global-space--normal:  16px; /* 1.0rem at base font 16px *\/
-  --global-space--large:   24px; /* 1.5rem at base font 16px *\/
-  --global-space--x-large: 48px; /* 3.0rem at base font 16px *\/
-  */
+  --global-space--xx-small: 2px; /* 0.125rem at base font 16px */
+  --global-space--x-small:  4px; /* 0.25rem at base font 16px */
+  --global-space--small:    8px; /* 0.5rem at base font 16px */
+  --global-space--normal:  16px; /* 1.0rem at base font 16px */
+  --global-space--large:   24px; /* 1.5rem at base font 16px */
+  --global-space--x-large: 48px; /* 3.0rem at base font 16px */
 
   --global-space--list-indent: 40px;   /* browser default (Firefox, Edge) */
   --global-space--grid-gap: 15px;      /* Bootstrap `.container` & `.row` */


### PR DESCRIPTION
## Overview

Use pixels for standard space props.

## Notes

This will ensure that if base font changes, spacing is not affected.

This is Designer decision from [Shared UI - Constants - Units](https://confluence.tacc.utexas.edu/x/dYAZCg).