### PR TITLE
feat(fp-1378): add new space prop --section-gap & fix(spacing): missing --global-space-beneath-main-content

### DIFF
--- a/source/_imports/elements/html-elements.css
+++ b/source/_imports/elements/html-elements.css
@@ -59,7 +59,7 @@ Styleguide Elements.ContentSectioning
 */
 
 main {
-  padding-bottom: var(--global-space-beneath-main-content);
+  padding-bottom: var(--global-space--section-gap);
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/source/_imports/objects/o-section.css
+++ b/source/_imports/objects/o-section.css
@@ -44,7 +44,7 @@ Styleguide Objects.Section
 
 .o-section {
   /* GH-99: Use standard spacing value */
-  padding-block: 45px; /* designs vary but this is the approx. average */
+  padding-block: var(--global-space--section-gap); /* ~avg. from design docs */
 }
 /* To distinguish nested sections */
 .o-section .o-section {

--- a/source/_imports/settings/props.space.css
+++ b/source/_imports/settings/props.space.css
@@ -31,5 +31,6 @@ Styleguide Settings.CustomProperties.Space
   --global-space--x-large: 3.0rem;     /* 48px (if base is 16px) */
 
   --global-space--list-indent: 40px;   /* browser default (Firefox, Edge) */
+  --global-space--section-gap: 45px;   /* recurring design doc spacing */
   --global-space--grid-gap: 15px;      /* Bootstrap `.container` & `.row` */
 }


### PR DESCRIPTION
## Overview

Create and use `--global-space--section-gap`.

## Related / Testing /  Screenshots

- https://github.com/TACC/Core-CMS/pull/480

## Changes

- add `--global-space--section-gap`
- use it for missing var `--global-space-beneath-main-content`
- use it for `.o-section` block padding