### PR TITLE
feat: nav component

### DIFF
--- a/source/_imports/components/c-nav.css
+++ b/source/_imports/components/c-nav.css
@@ -55,7 +55,7 @@ nav.c-nav--boxed ul {
 }
 
 /* ordered list (wide) */
-@media (--narrow-and-above) {
+@media (--medium-and-above) {
   nav.c-nav--boxed ol {
     /* We retain bullets, which (wide screen) need large padding (so keep it) */
     /* padding-left: var(--large-indent); *//* comes from `html-elements.css` */
@@ -63,7 +63,7 @@ nav.c-nav--boxed ul {
   }
 }
 /* ordered list (narrow) */
-@media (--narrow-and-below) {
+@media (--medium-and-below) {
   nav.c-nav--boxed ol {
     /* We retain bullets, which (narrow screen) don't need large padding left */
     padding-left: var(--small-indent); /* overwrite `html-elements.css` */
@@ -89,7 +89,7 @@ nav.c-nav--boxed.c-nav--no-list {
 
 
 
-/* Content */
+/* Elements */
 
 
 
@@ -109,9 +109,9 @@ nav.c-nav--no-list > a {
 
 
 
-/* Content: Narrow Screen */
+/* Elements: Narrow Screen */
 
-@media (--narrow-and-below) {
+@media (--medium-and-below) {
 
   /* any list */
   nav.c-nav :is(ul,ol) {

--- a/source/_imports/components/c-nav.css
+++ b/source/_imports/components/c-nav.css
@@ -1,0 +1,138 @@
+/*
+Nav
+
+Navigation links that flows inline on narrow screens.
+
+To enforce appropriate semantic HTML, a `<nav>` is required.
+
+For list-like navigation, use `<ul>` or `<ol>` (with children `<li>`). Inside this kind of nav, markup whitespace is __not__ rendered.
+
+To support a navigation not as a list and with direct `<a>` children, add class `c-nav--no-list`. Inside this kind of nav, markup whitespace __is__ rendered.﹡
+
+﹡ To remove whitespace with CSS would break or complicate font-size cascade.
+- c-nav--boxed - Surrounded by a box
+
+Markup: c-nav.html
+
+Styleguide Components.Nav
+*/
+@import url("_imports/tools/media-queries.css");
+
+
+
+
+
+/* Modifiers */
+
+
+
+/* Modifiers: Boxed */
+
+nav.c-nav--boxed {
+  --small-indent: calc(var(--global-space--list-indent) / 2);
+  --large-indent: var(--global-space--list-indent);
+
+  width: fit-content;
+  padding-block: var(--small-indent);
+
+  border: var(--global-border--normal);
+
+  line-height: 2em;
+}
+
+/* any list */
+nav.c-nav--boxed :is(ul,ol) {
+  margin: 0;
+}
+
+/* Modifiers: Boxed: Padding */
+
+/* unordered list */
+nav.c-nav--boxed ul {
+  list-style-type: none; /* to remove bullets (must then reduce padding left) */
+  padding-left: var(--small-indent); /* overwrite `html-elements.css` */
+  padding-right: var(--large-indent);
+}
+
+/* ordered list (wide) */
+@media (--narrow-and-above) {
+  nav.c-nav--boxed ol {
+    /* We retain bullets, which (wide screen) need large padding (so keep it) */
+    /* padding-left: var(--large-indent); *//* comes from `html-elements.css` */
+    padding-right: var(--large-indent);
+  }
+}
+/* ordered list (narrow) */
+@media (--narrow-and-below) {
+  nav.c-nav--boxed ol {
+    /* We retain bullets, which (narrow screen) don't need large padding left */
+    padding-left: var(--small-indent); /* overwrite `html-elements.css` */
+    padding-right: var(--large-indent);
+  }
+}
+
+/* no list */
+nav.c-nav--boxed.c-nav--no-list {
+  /* Has no bullets, thus smaller padding left */
+  padding-left: var(--small-indent);
+  padding-right: var(--large-indent);
+}
+
+
+
+/* Modifiers: No List */
+
+/* This is not a true modifier. It is required to support certain markup. */
+/* SEE: stylesheet docblock, "no list" comments, `...--no-list` selectors */
+
+
+
+
+
+/* Content */
+
+
+
+nav.c-nav {
+  --space-between-inline-items: 0.5em;
+}
+
+/* no list */
+nav.c-nav--no-list > a {
+  display: inline-block;
+
+  /* To space content via margin (must then be re-aligned with container) */
+  margin-left: var(--space-between-inline-items);
+  /* To re-align content to container (after they were spaced via margin) */
+  transform: translateX(calc(-1 * var(--space-between-inline-items)));
+}
+
+
+
+/* Content: Narrow Screen */
+
+@media (--narrow-and-below) {
+
+  /* any list */
+  nav.c-nav :is(ul,ol) {
+    display: flex;
+    flex-wrap: wrap;
+
+    /* To prevent overlap of any lists' decorators (when items are inline) */
+    list-style-position: inside;
+  }
+  nav.c-nav :is(ul,ol):not(.c-nav--boxed :is(ul,ol)) {
+    /* To remove padding because list decorators are `...position: inside` */
+    padding-left: unset;
+  }
+  nav.c-nav :is(ul,ol) li {
+    /* To space content via margin (must then be re-aligned with container) */
+    margin-left: var(--space-between-inline-items);
+    /* To re-align content to container (after they were spaced via margin) */
+    transform: translateX(calc(-1 * var(--space-between-inline-items)));
+  }
+
+  /* unordered list */
+  nav.c-nav ul { list-style-type: none; }
+
+}

--- a/source/_imports/components/c-nav.css
+++ b/source/_imports/components/c-nav.css
@@ -39,6 +39,7 @@ nav.c-nav {
 /* Modifiers: Boxed */
 
 nav.c-nav--boxed {
+  --x-small-indent: calc(var(--global-space--list-indent) / 4);
   --small-indent: calc(var(--global-space--list-indent) / 2);
   --large-indent: var(--global-space--list-indent);
 
@@ -64,6 +65,7 @@ nav.c-nav--boxed ul {
 /* wide screen */
 @media (--medium-and-above) {
   nav.c-nav--boxed {
+    /* Normal vertical padding */
     padding-block: var(--small-indent);
   }
 
@@ -77,7 +79,8 @@ nav.c-nav--boxed ul {
 /* narrow screen */
 @media (--medium-and-below) {
   nav.c-nav--boxed {
-    padding-block: calc( var(--small-indent) - var(--link-padding) );
+    /* Reduced vertical padding because of narrow screen link line-height */
+    padding-block: var(--x-small-indent);
   }
 
   nav.c-nav--boxed ol {
@@ -113,12 +116,14 @@ nav.c-nav {
   --space-between-inline-items: 0.5em;
 }
 nav.c-nav a {
+  display: inline-block; /* to let line-height define clickable area */
   padding-inline: var(--link-padding);
 }
 
 /* no list */
 nav.c-nav--no-list {
   display: flex; /* to remove whitespace between items */
+  flex-wrap: wrap;
 }
 nav.c-nav--no-list > a {
   /* To space items via margin (use `-right` to not increase left indent) */

--- a/source/_imports/components/c-nav.css
+++ b/source/_imports/components/c-nav.css
@@ -113,11 +113,13 @@ nav.c-nav {
   --space-between-inline-items: 0.5em;
 }
 nav.c-nav a {
-  display: inline-block;
   padding-inline: var(--link-padding);
 }
 
 /* no list */
+nav.c-nav--no-list {
+  display: flex; /* to remove whitespace between items */
+}
 nav.c-nav--no-list > a {
   /* To space items via margin (use `-right` to not increase left indent) */
   margin-right: var(--space-between-inline-items);

--- a/source/_imports/components/c-nav.css
+++ b/source/_imports/components/c-nav.css
@@ -22,6 +22,16 @@ Styleguide Components.Nav
 
 
 
+/* Block */
+
+nav.c-nav {
+  --link-padding: 0.5em;
+}
+
+
+
+
+
 /* Modifiers */
 
 
@@ -33,11 +43,8 @@ nav.c-nav--boxed {
   --large-indent: var(--global-space--list-indent);
 
   width: fit-content;
-  padding-block: var(--small-indent);
 
   border: var(--global-border--normal);
-
-  line-height: 2em;
 }
 
 /* any list */
@@ -50,24 +57,33 @@ nav.c-nav--boxed :is(ul,ol) {
 /* unordered list */
 nav.c-nav--boxed ul {
   list-style-type: none; /* to remove bullets (must then reduce padding left) */
-  padding-left: var(--small-indent); /* overwrite `html-elements.css` */
+  padding-left: var(--small-indent);
   padding-right: var(--large-indent);
 }
 
-/* ordered list (wide) */
+/* wide screen */
 @media (--medium-and-above) {
+  nav.c-nav--boxed {
+    padding-block: var(--small-indent);
+  }
+
   nav.c-nav--boxed ol {
     /* We retain bullets, which (wide screen) need large padding (so keep it) */
-    /* padding-left: var(--large-indent); *//* comes from `html-elements.css` */
-    padding-right: var(--large-indent);
+    padding-left: var(--large-indent);
+    padding-right: calc( var(--large-indent) - var(--link-padding) );
   }
 }
-/* ordered list (narrow) */
+
+/* narrow screen */
 @media (--medium-and-below) {
+  nav.c-nav--boxed {
+    padding-block: calc( var(--small-indent) - var(--link-padding) );
+  }
+
   nav.c-nav--boxed ol {
     /* We retain bullets, which (narrow screen) don't need large padding left */
-    padding-left: var(--small-indent); /* overwrite `html-elements.css` */
-    padding-right: var(--large-indent);
+    padding-left: calc( var(--small-indent) - var(--link-padding) );
+    padding-right: calc( var(--large-indent) - var(--link-padding) );
   }
 }
 
@@ -96,15 +112,15 @@ nav.c-nav--boxed.c-nav--no-list {
 nav.c-nav {
   --space-between-inline-items: 0.5em;
 }
+nav.c-nav :is(ul,ol) a {
+  display: inline-block;
+  padding-inline: var(--link-padding);
+}
 
 /* no list */
 nav.c-nav--no-list > a {
-  display: inline-block;
-
-  /* To space content via margin (must then be re-aligned with container) */
-  margin-left: var(--space-between-inline-items);
-  /* To re-align content to container (after they were spaced via margin) */
-  transform: translateX(calc(-1 * var(--space-between-inline-items)));
+  /* To space items via margin (use `-right` to not increase left indent) */
+  margin-right: var(--space-between-inline-items);
 }
 
 
@@ -112,6 +128,10 @@ nav.c-nav--no-list > a {
 /* Elements: Narrow Screen */
 
 @media (--medium-and-below) {
+
+  nav.c-nav a {
+    line-height: 2.5;
+  }
 
   /* any list */
   nav.c-nav :is(ul,ol) {
@@ -126,10 +146,8 @@ nav.c-nav--no-list > a {
     padding-left: unset;
   }
   nav.c-nav :is(ul,ol) li {
-    /* To space content via margin (must then be re-aligned with container) */
-    margin-left: var(--space-between-inline-items);
-    /* To re-align content to container (after they were spaced via margin) */
-    transform: translateX(calc(-1 * var(--space-between-inline-items)));
+    /* To space items via margin (use `-right` to not increase left indent) */
+    margin-right: var(--space-between-inline-items);
   }
 
   /* unordered list */

--- a/source/_imports/components/c-nav.css
+++ b/source/_imports/components/c-nav.css
@@ -112,7 +112,7 @@ nav.c-nav--boxed.c-nav--no-list {
 nav.c-nav {
   --space-between-inline-items: 0.5em;
 }
-nav.c-nav :is(ul,ol) a {
+nav.c-nav a {
   display: inline-block;
   padding-inline: var(--link-padding);
 }

--- a/source/_imports/components/c-nav.css
+++ b/source/_imports/components/c-nav.css
@@ -39,9 +39,9 @@ nav.c-nav {
 /* Modifiers: Boxed */
 
 nav.c-nav--boxed {
-  --x-small-indent: calc(var(--global-space--list-indent) / 4);
-  --small-indent: calc(var(--global-space--list-indent) / 2);
-  --large-indent: var(--global-space--list-indent);
+  --indent-small: calc(var(--global-space--list-indent) / 4);
+  --indent-medium: calc(var(--global-space--list-indent) / 2);
+  --indent-large: var(--global-space--list-indent);
 
   width: fit-content;
 
@@ -58,21 +58,21 @@ nav.c-nav--boxed :is(ul,ol) {
 /* unordered list */
 nav.c-nav--boxed ul {
   list-style-type: none; /* to remove bullets (must then reduce padding left) */
-  padding-left: var(--small-indent);
-  padding-right: var(--large-indent);
+  padding-left: var(--indent-medium);
+  padding-right: var(--indent-large);
 }
 
 /* wide screen */
 @media (--medium-and-above) {
   nav.c-nav--boxed {
     /* Normal vertical padding */
-    padding-block: var(--small-indent);
+    padding-block: var(--indent-medium);
   }
 
   nav.c-nav--boxed ol {
     /* We retain bullets, which (wide screen) need large padding (so keep it) */
-    padding-left: var(--large-indent);
-    padding-right: calc( var(--large-indent) - var(--link-padding) );
+    padding-left: var(--indent-large);
+    padding-right: calc( var(--indent-large) - var(--link-padding) );
   }
 }
 
@@ -80,21 +80,21 @@ nav.c-nav--boxed ul {
 @media (--medium-and-below) {
   nav.c-nav--boxed {
     /* Reduced vertical padding because of narrow screen link line-height */
-    padding-block: var(--x-small-indent);
+    padding-block: var(--indent-small);
   }
 
   nav.c-nav--boxed ol {
     /* We retain bullets, which (narrow screen) don't need large padding left */
-    padding-left: calc( var(--small-indent) - var(--link-padding) );
-    padding-right: calc( var(--large-indent) - var(--link-padding) );
+    padding-left: calc( var(--indent-medium) - var(--link-padding) );
+    padding-right: calc( var(--indent-large) - var(--link-padding) );
   }
 }
 
 /* no list */
 nav.c-nav--boxed.c-nav--no-list {
   /* Has no bullets, thus smaller padding left */
-  padding-left: var(--small-indent);
-  padding-right: var(--large-indent);
+  padding-left: var(--indent-medium);
+  padding-right: var(--indent-large);
 }
 
 

--- a/source/_imports/components/c-nav.html
+++ b/source/_imports/components/c-nav.html
@@ -1,0 +1,45 @@
+{# The {{ html }} allows DjangoCMS Snippet to pass in class names #}
+
+<h3>Unordered List</h3>
+<nav class="c-nav {{modifier_class}} {{ html }}">
+  <ul>
+    <li><a href="#alabama">Alabama</a></li>
+    <li><a href="#alaska">Alaska</a></li>
+    <li><a href="#arizona">Arizona</a></li>
+    <li><a href="#arkansas">Arkansas</a></li>
+    <li><a href="#california">California</a></li>
+    <li><a href="#colorado">Colorado</a></li>
+    <li><a href="#connecticut">Connecticut</a></li>
+    <li><a href="#deleware">Delware</a></li>
+    <li><a href="#florida">Florida</a></li>
+  </ul>
+</nav>
+
+<h3>Ordered List</h3>
+<nav class="c-nav {{modifier_class}} {{ html }}">
+  <ol>
+    <li><a href="#alabama">Alabama</a></li>
+    <li><a href="#alaska">Alaska</a></li>
+    <li><a href="#arizona">Arizona</a></li>
+    <li><a href="#arkansas">Arkansas</a></li>
+    <li><a href="#california">California</a></li>
+    <li><a href="#colorado">Colorado</a></li>
+    <li><a href="#connecticut">Connecticut</a></li>
+    <li><a href="#deleware">Delware</a></li>
+    <li><a href="#florida">Florida</a></li>
+  </ol>
+</nav>
+
+<h3>No List</h3>
+<p>(requires <code>c-nav--no-list</code>)</p>
+<nav class="c-nav c-nav--no-list {{modifier_class}} {{ html }}">
+  <a href="#alabama">Alabama</a>
+  <a href="#alaska">Alaska</a>
+  <a href="#arizona">Arizona</a>
+  <a href="#arkansas">Arkansas</a>
+  <a href="#california">California</a>
+  <a href="#colorado">Colorado</a>
+  <a href="#connecticut">Connecticut</a>
+  <a href="#deleware">Delware</a>
+  <a href="#florida">Florida</a>
+</nav>


### PR DESCRIPTION
### Overview / Changes

Add nav component.

### Related

- [ECEP-114](https://jira.tacc.utexas.edu/browse/ECEP-114)
- required by https://github.com/TACC/Core-CMS/pull/464
- required by [another ECEP-114 PR yet to be made]

### Testing / Screenshots

1. Review [Core Nav Pattern (dev)].
1. Change screen size from wide to narrow and back.
1. On wide screen:
    - links should have **less** space between them.
    - link vertical clickable area should extend **a tad** beyond its text
    - link horizontal clickable area should extend _a tad_ beyond its text
1. On narrow screen:
    - links should have **more** space between them
    - link vertical clickable area should extend **well** beyond its text
    - link horizontal clickable area should extend _a tad_ beyond its text
1. Previous features must not have changed:
    - boxed unordered list item have bullets prefixes
    - ordered list items have numerical prefixes
    - no list links line up on a row **and** wrap

<details><summary><sub>* <strong>If</strong> you want to test locally, <strong>then</strong> create these snippets (click to reveal):</sub></summary>

> HTML: "(basic)"
> TEMPLATE: `snippets/manual-pattern-library/c-nav.html`

> HTML: `c-nav--boxed`
> TEMPLATE: `snippets/manual-pattern-library/c-nav.html`

</details>

[Core Nav Pattern (dev)]: https://dev.cep.tacc.utexas.edu/design-system/ui-patterns/c-nav/