### PR TITLE
feat: position sticky support on CMS

### DIFF
--- a/source/_imports/components/django.cms.css
+++ b/source/_imports/components/django.cms.css
@@ -11,15 +11,24 @@ Reference:
 Styleguide Components.DjangoCMS
 */
 
-/* Prevent excess scrollbar when CMS admin is logged in */
+/* Prevent excess scrollbar when logged into Django CMS */
 /* NOTE: This code does NOT work */
 /*
 .cms-ready body {
   /* FAQ: CMS dynamically adds `margin-top` to `head` to fit toolbar height *\/
   /* WARNING: If the dynamic(!) header margin changes, then so should this *\/
   /* RFC: Consider creating JavaScript snippet (via CMS?) to solve this *\/
-  --head-margin-top: 46px;
-
-  height: calc(100vh - var(--head-margin-top));
+  height: calc(100vh - env(--cms-toolbar-height));
 }
 */
+
+/* Prevent anchor links from scrolling behind Django CMS header */
+.cms-ready :target {
+  scroll-margin-top: env(--cms-toolbar-height);
+}
+
+/* Prevent top-sticking content from scrolling behind Django CMS header */
+.cms-ready .sticky-top /* Bootstrap class */,
+.cms-ready .position-sticky.fixed-top /* Bootstrap class */ {
+  top: env(--cms-toolbar-height);
+}

--- a/source/_imports/objects/o-section.css
+++ b/source/_imports/objects/o-section.css
@@ -266,5 +266,5 @@ Styleguide Objects.Section
 
 /* HACK: To hide `.o-section__banner-image` overflow */
 main {
-  overflow-x: hidden;
+  overflow-x: clip; /* support position sticky on element in section */
 }

--- a/source/_themes/default.json
+++ b/source/_themes/default.json
@@ -4,6 +4,9 @@
   "name": "default",
 
   "environment-variables": {
+    "// CMS": "",
+    "--cms-toolbar-height": "46px",
+
     "// HEADER": "",
     "--header-text-color": "var(--global-color-primary--xx-light)",
     "--header-bkgd-color": "var(--global-color-primary--xx-dark)",

--- a/source/_themes/has-dark-logo.json
+++ b/source/_themes/has-dark-logo.json
@@ -4,6 +4,9 @@
   "name": "has-dark-logo",
 
   "environment-variables": {
+    "// CMS": "",
+    "--cms-toolbar-height": "46px",
+
     "// HEADER": "",
     "--header-text-color": "var(--global-color-primary--x-dark)",
     "--header-bkgd-color": "var(--global-color-primary--x-light)",


### PR DESCRIPTION
### Overview / Changes

Support `position: sticky` elements (using Bootstrap class) for Django CMS.

### Related

- [ECEP-114](https://jira.tacc.utexas.edu/browse/ECEP-114)
- required by https://github.com/TACC/Core-CMS/pull/464

### Testing / Screenshots

https://github.com/TACC/Core-CMS/pull/464