### PR TITLE
feat(object): o-flex-item-table-wrap (Core-Portal)

### DIFF
--- a/source/_imports/objects/o-flex-item-table-wrap.css
+++ b/source/_imports/objects/o-flex-item-table-wrap.css
@@ -1,0 +1,50 @@
+/*
+Flex-Item Table-Wrap
+
+A wrapper to allow a table to behave like a flex item (because a `<table>` can __not__ be a flex item).
+
+Reference:
+- [Why does flex-box work with a div, but not a table?](https://stackoverflow.com/q/41421512/11817077))
+
+Markup:
+<section style="display: flex; flex-direction: column">
+  <header>Section Title</header>
+  <p>Section/Table Description</p>
+  <div class="o-flex-item-table-wrap">
+    <table>
+        <thead>
+          <tr>
+            <th>A</th>
+            <th>B</th>
+            <th>C</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>A</td>
+            <td>B</td>
+            <td>C</td>
+          </tr>
+        </thead>
+    </table>
+  </div>
+</section>
+
+Styleguide Objects.FlexItemTableWrap
+*/
+/* Constrain stretched <table>'s position and dimension */
+.o-flex-item-table-wrap {
+  /* Ensure wrapper has dimensions (which will be remaining space in parent) */
+  flex-grow: 1;
+
+  /* Set position and maximum dimensions for child <table> */
+  position: relative;
+}
+/* Strech <table> to fill available space of flex item (the wrapper) */
+.o-flex-item-table-wrap > table {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}


### PR DESCRIPTION
## Overview / Changes

Copy object module `o-flex-item-table-wrap` from [TACC/Core-Portal](https://github.com/TACC/Core-Portal/blob/d136b2a/client/src/styles/objects/o-flex-item-table-wrap.css).

## Related

- required by https://github.com/wesleyboar/Core-Components

## Testing / Screenshots

Skipped. Portal uses it. Core-Components uses it. Just need the styles available import as is. It was already modular.
