### PR TITLE
feat(tup-151): offset content less offset

### DIFF
--- a/source/_imports/objects/o-offset-content.css
+++ b/source/_imports/objects/o-offset-content.css
@@ -16,7 +16,7 @@ Styleguide Objects.OffsetContent
 
 
 :--o-offset-content {
-  --offset-distance: min(30vw, 410px);
+  --offset-distance: min(15vw, 410px);
 	--buffer: calc( 2 * var(--global-space--grid-gap) );
 }
 


### PR DESCRIPTION
## Overview

Reduce offset content default distance.

<details>Only used ECEP and TUP, which use default styles, and Texascale which overrides value. This accommodates news articles being centered (), which gave offset content less space.</details>

## Related

- [TUP-151](https://jira.tacc.utexas.edu/browse/TUP-151)
- required by and requires https://github.com/TACC/Core-CMS/pull/488

## Changes

- reduce offset distance

## Testing & Screenshots

See https://github.com/TACC/Core-CMS/pull/488.