### PR TITLE
fix(x-truncate): typo kills x-truncate--one-line

### DIFF
--- a/source/_imports/tools/x-truncate.css
+++ b/source/_imports/tools/x-truncate.css
@@ -33,7 +33,7 @@ Styleguide Tools.ExtendsAndMixins.Truncate
 /* One Line */
 
 .x-truncate--one-line, /* DEPRECATED */
-%x-truncate--one-line, {
+%x-truncate--one-line {
 	text-overflow: var(--text-overflow, ellipsis);
 
 	overflow: hidden;


### PR DESCRIPTION
## Overview / Changes

Fix typo that was rendering `%x-truncate--one-line` unusable.

## Related / Testing / Screenshots

N/A