### PR TITLE
fix(fp-1542): figure img margin for link img's too

### DIFF
--- a/source/_imports/elements/figure.css
+++ b/source/_imports/elements/figure.css
@@ -11,7 +11,7 @@ Reference:
 Styleguide Elements.TextContent.Figure
 */
 
-figure > a,
+figure > a > img,
 figure > img {
   margin-bottom: 20px;
 }

--- a/source/_imports/elements/figure.css
+++ b/source/_imports/elements/figure.css
@@ -11,6 +11,7 @@ Reference:
 Styleguide Elements.TextContent.Figure
 */
 
+figure > a,
 figure > img {
   margin-bottom: 20px;
 }


### PR DESCRIPTION
## Overview

Figure images that are nested in anchor tags should also have margin-bottom, not just unlinked figure images.

## Related

- [FP-1542](https://jira.tacc.utexas.edu/browse/FP-1542)
- required by https://github.com/TACC/Core-CMS/pull/493

## Changes

- margin-bottom for linked figure images too

## Testing / Screenshots

See https://github.com/TACC/Core-CMS/pull/493.
