### PR TITLE
chore(version): v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2022-25-11: Simpler CLI API, Fixes, Updates, Cleanup
+
+### Changed
+
+- feat(tup-151): offset content less offset (#21)
+- FP-1648: Build Individual Stylesheets — ⚠️ API Change (#23)
+- feat(fp-1491): c-button updates from portal & use x-truncate (#20)
+
+### Fixed
+
+- fix(x-truncate): typo kills x-truncate--one-line (#22)
+- fix(FP-1596): pagination @import used external url
+- fix(fp-1542): figure img margin for link img's too (#25)
+
+### Deleted
+
+- chore(gitignore): remove outdated file
+
 ## [2.0.0] - 2022-05-11: Return Some CMS Styles, Many New Patterns
 
 ### Added
@@ -81,7 +99,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial working code. (This code may not work on all environments.)
 
-[unreleased]: https://github.com/TACC/Core-Styles/compare/v2.0.0...HEAD
+[unreleased]: https://github.com/TACC/Core-Styles/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/TACC/Core-Styles/releases/tag/v3.0.0
 [2.0.0]: https://github.com/TACC/Core-Styles/releases/tag/v2.0.0
 [1.0.0]: https://github.com/TACC/Core-Styles/releases/tag/v1.0.0
 [0.2.0]: https://github.com/TACC/Core-Styles/releases/tag/v0.2.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tacc/core-styles",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "license": "MIT",
   "author": "TACC ACI WMA <wma-portals@gmail.com>",
   "description": "CSS source and processor for TACC Core-CMS and Core-Portal.",


### PR DESCRIPTION
## Overview

Bump version (to prepare for use by client software PRs).

## Notes

After this, I'll change v1–v3 to v0.3–v0.5, because this repo is still not stable.