### PR TITLE
chore(version): v3.0→v0.5 & publish instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.0.0] - 2022-25-11: Simpler CLI API, Fixes, Updates, Cleanup
+## [0.5.0] - 2022-25-11: Simpler CLI API, Fixes, Updates, Cleanup
 
 ### Added
 
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - chore(gitignore): remove outdated file
 
-## [2.0.0] - 2022-05-11: Return Some CMS Styles, Many New Patterns
+## [0.4.0] - 2022-05-11: Return Some CMS Styles, Many New Patterns
 
 ### Added
 
@@ -61,7 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - chore(gh-149): remove deleted id selector (#7)
 
-## [1.0.0] - 2022-04-06: Initial Release
+## [0.3.0] - 2022-04-06: Initial Release
 
 ### Added
 
@@ -103,9 +103,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial working code. (This code may not work on all environments.)
 
-[unreleased]: https://github.com/TACC/Core-Styles/compare/v3.0.0...HEAD
-[3.0.0]: https://github.com/TACC/Core-Styles/releases/tag/v3.0.0
-[2.0.0]: https://github.com/TACC/Core-Styles/releases/tag/v2.0.0
-[1.0.0]: https://github.com/TACC/Core-Styles/releases/tag/v1.0.0
+[unreleased]: https://github.com/TACC/Core-Styles/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/TACC/Core-Styles/releases/tag/v0.5.0
+[0.4.0]: https://github.com/TACC/Core-Styles/releases/tag/v0.4.0
+[0.3.0]: https://github.com/TACC/Core-Styles/releases/tag/v0.3.0
 [0.2.0]: https://github.com/TACC/Core-Styles/releases/tag/v0.2.0
 [0.1.0]: https://github.com/TACC/Core-Styles/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -222,6 +222,15 @@ We use a modifed version of [GitFlow](https://datasift.github.io/gitflow/Introdu
 
 Sign your commits ([see this link](https://help.github.com/en/github/authenticating-to-github/managing-commit-signature-verification) for help)
 
+### Publishing Workflow
+
+1. Create new branch for version bump.
+1. Update `CHANGELOG.md`.
+1. Update version in `package.json`.
+1. Run `npm i --package-lock-only` to update version in `package-lock.json`.
+1. Commit, push, PR, review, merge.
+1. Create new GitHub Release.
+
 ### Resources
 
 * [Learn Markdown](https://bitbucket.org/tutorials/markdowndemo)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tacc/core-styles",
-  "version": "0.2.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tacc/core-styles",
-      "version": "0.2.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tacc/core-styles",
-  "version": "3.0.0",
+  "version": "0.5.0",
   "license": "MIT",
   "author": "TACC ACI WMA <wma-portals@gmail.com>",
   "description": "CSS source and processor for TACC Core-CMS and Core-Portal.",


### PR DESCRIPTION
## Overview

Change versions (to reflect volatile state of API):

| | | | |
| - | - | - | - |
| from | v1.0.0 | v2.0.0 | v3.0.0 |
| to | v0.3.0 | v0.4.0 | v0.5.0 |

## Related

many open PRs that should point to a specific version (or commit)

## Changes

- version change (package, package-lock, changelog)
- add publish instructions to readme
- (external) changed all git tags[^1] and GitHub releases

[^1]: The new git tags were also annotated with the commit message.

## Testing /Screenshots

N/A