### PR TITLE
chore(version): v0.5.0→v0.5.1 & instructions tweak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.0] - 2022-25-11: Simpler CLI API, Fixes, Updates, Cleanup
+## [0.5.1] - 2022-05-26: Version Rewrite
+
+### Changed
+
+- chore(version): v3.0→v0.5 & publish instructions (#28)
+
+## [0.5.0] - 2022-05-25: Simpler CLI API, Fixes, Updates, Cleanup
 
 ### Added
 
@@ -103,7 +109,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial working code. (This code may not work on all environments.)
 
-[unreleased]: https://github.com/TACC/Core-Styles/compare/v0.5.0...HEAD
+[unreleased]: https://github.com/TACC/Core-Styles/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/TACC/Core-Styles/releases/tag/v0.5.1
 [0.5.0]: https://github.com/TACC/Core-Styles/releases/tag/v0.5.0
 [0.4.0]: https://github.com/TACC/Core-Styles/releases/tag/v0.4.0
 [0.3.0]: https://github.com/TACC/Core-Styles/releases/tag/v0.3.0

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Sign your commits ([see this link](https://help.github.com/en/github/authenticat
 1. Create new branch for version bump.
 1. Update `CHANGELOG.md`.
 1. Update version in `package.json`.
-1. Run `npm i --package-lock-only` to update version in `package-lock.json`.
+1. Update version in `package-lock.json` by running `npm i --package-lock-only`.
 1. Commit, push, PR, review, merge.
 1. Create new GitHub Release.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tacc/core-styles",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tacc/core-styles",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tacc/core-styles",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "author": "TACC ACI WMA <wma-portals@gmail.com>",
   "description": "CSS source and processor for TACC Core-CMS and Core-Portal.",


### PR DESCRIPTION
## Overview

Version update from v0.5.0 to v0.5.1.

## Changes

- update changelog
- update version in `package.json`
- update version in `package-lock.json` (manually, because `npm i --package-lock-only` did not work)
- fix date of v0.5.0 release
- tweak publish instructions