### PR TITLE
fix(fp-1678): small button a bit more vert pad

### DIFF
--- a/source/_imports/components/c-button.css
+++ b/source/_imports/components/c-button.css
@@ -257,7 +257,7 @@ Styleguide Components.Button
 }
 .c-button--size-small {
   min-width: 0;
-  padding: 3px 9px;
+  padding: 4px 9px;
   line-height: 1;
 }
 


### PR DESCRIPTION
## Overview

A tiny bit more vertical padding for buttons ([reason](https://tacc-team.slack.com/archives/CQUA4D5KJ/p1654877292004179?thread_ts=1654815547.469369&cid=CQUA4D5KJ)).

## Related

- https://github.com/TACC/Core-Portal/pull/649

## Changes

- padding tweak

## Testing

Skipped.

## Screenshots

Negligible.
