### PR TITLE
feat: use relative paths like tup-ui

### DIFF
--- a/src/lib/_imports/components/bootstrap.container.css
+++ b/src/lib/_imports/components/bootstrap.container.css
@@ -7,7 +7,7 @@ Add to Bootstrap styles. See:
 
 Styleguide Components.Bootstrap.Grid
 */
-@import url("_imports/tools/media-queries.css");
+@import url("../tools/media-queries.css");
 
 @media (--x-wide-and-above) {
   .container { max-width: var(--global-max-width--x-wide); }

--- a/src/lib/_imports/components/bootstrap.pagination.css
+++ b/src/lib/_imports/components/bootstrap.pagination.css
@@ -7,7 +7,7 @@ Style Bootstrap pagination. See:
 
 Styleguide Components.Bootstrap.Pagination
 */
-@import url("_imports/components/c-page.css");
+@import url("../components/c-page.css");
 
 
 

--- a/src/lib/_imports/components/c-button.css
+++ b/src/lib/_imports/components/c-button.css
@@ -14,7 +14,7 @@ Markup: c-button.html
 
 Styleguide Components.Button
 */
-@import url("_imports/tools/x-truncate.css");
+@import url("../tools/x-truncate.css");
 
 
 

--- a/src/lib/_imports/components/c-callout.css
+++ b/src/lib/_imports/components/c-callout.css
@@ -7,8 +7,8 @@ Markup: c-callout.html
 
 Styleguide Components.Callout
 */
-@import url("_imports/tools/media-queries.css");
-@import url("_imports/tools/x-article-link.css");
+@import url("../tools/media-queries.css");
+@import url("../tools/x-article-link.css");
 
 
 

--- a/src/lib/_imports/components/c-card.css
+++ b/src/lib/_imports/components/c-card.css
@@ -11,7 +11,7 @@ Markup: c-card.html
 
 Styleguide Components.Card
 */
-@import url("_imports/tools/x-article-link.css");
+@import url("../tools/x-article-link.css");
 
 /* Modifiers */
 

--- a/src/lib/_imports/components/c-data-list.css
+++ b/src/lib/_imports/components/c-data-list.css
@@ -29,7 +29,7 @@ Markup: c-data-list.html
 
 Styleguide Components.DataList
 */
-@import url("_imports/tools/x-truncate.css");
+@import url("../tools/x-truncate.css");
 
 
 

--- a/src/lib/_imports/components/c-nav.css
+++ b/src/lib/_imports/components/c-nav.css
@@ -17,7 +17,7 @@ Markup: c-nav.html
 
 Styleguide Components.Nav
 */
-@import url("_imports/tools/media-queries.css");
+@import url("../tools/media-queries.css");
 
 
 

--- a/src/lib/_imports/components/c-see-all-link.css
+++ b/src/lib/_imports/components/c-see-all-link.css
@@ -11,7 +11,7 @@ Markup:
 
 Styleguide Components.SeeAllLink
 */
-@import url("_imports/tools/x-truncate.css");
+@import url("../tools/x-truncate.css");
 
 
 

--- a/src/lib/_imports/components/c-show-more.css
+++ b/src/lib/_imports/components/c-show-more.css
@@ -11,7 +11,7 @@ A CSS-only way to support a "Show More…" feature. It requires a container and 
 
 Styleguide: Components.ShowMore
 */
-@import url("_imports/tools/x-truncate.css");
+@import url("../tools/x-truncate.css");
 
 /* Truncation */
 

--- a/src/lib/_imports/objects/o-grid.css
+++ b/src/lib/_imports/objects/o-grid.css
@@ -15,8 +15,8 @@ Markup: o-grid.html
 
 Styleguide Objects.Grid
 */
-@import url("_imports/tools/media-queries.css");
-@import url("_imports/tools/x-grid.css");
+@import url("../tools/media-queries.css");
+@import url("../tools/x-grid.css");
 
 
 

--- a/src/lib/_imports/objects/o-offset-content.css
+++ b/src/lib/_imports/objects/o-offset-content.css
@@ -5,7 +5,7 @@ Content that should be offset from the flow of text within which it is placed.
 
 Styleguide Objects.OffsetContent
 */
-@import url("_imports/tools/media-queries.css");
+@import url("../tools/media-queries.css");
 
 
 

--- a/src/lib/_imports/objects/o-section.css
+++ b/src/lib/_imports/objects/o-section.css
@@ -32,9 +32,9 @@ Markup: o-section.html
 
 Styleguide Objects.Section
 */
-@import url("_imports/tools/media-queries.css");
-@import url("_imports/tools/x-layout.css");
-@import url("_imports/tools/x-fake-border.css");
+@import url("../tools/media-queries.css");
+@import url("../tools/x-layout.css");
+@import url("../tools/x-fake-border.css");
 
 
 

--- a/src/lib/_imports/tools/x-layout.css
+++ b/src/lib/_imports/tools/x-layout.css
@@ -11,7 +11,7 @@ Styles that allow re-usable layouts.
 
 Styleguide Tools.ExtendsAndMixins.Layout
 */
-@import url("_imports/tools/media-queries.css");
+@import url("../tools/media-queries.css");
 
 
 

--- a/src/lib/_imports/trumps/s-article-list.css
+++ b/src/lib/_imports/trumps/s-article-list.css
@@ -7,9 +7,9 @@ Markup: s-article-list.html
 
 Styleguide Trumps.Scopes.ArticleList
 */
-@import url("_imports/tools/x-truncate.css");
-@import url("_imports/tools/x-layout.css");
-@import url("_imports/tools/x-article-link.css");
+@import url("../tools/x-truncate.css");
+@import url("../tools/x-layout.css");
+@import url("../tools/x-article-link.css");
 
 
 

--- a/src/lib/_imports/trumps/s-article-preview.css
+++ b/src/lib/_imports/trumps/s-article-preview.css
@@ -7,8 +7,8 @@ Markup: s-article-preview.html
 
 Styleguide Trumps.Scopes.ArticlePreview
 */
-@import url("_imports/tools/x-truncate.css");
-@import url("_imports/tools/x-article-link.css");
+@import url("../tools/x-truncate.css");
+@import url("../tools/x-article-link.css");
 
 
 

--- a/src/lib/_imports/trumps/s-breadcrumbs.css
+++ b/src/lib/_imports/trumps/s-breadcrumbs.css
@@ -25,7 +25,7 @@ Markup:
 
 Styleguide Trumps.Scopes.Breadcrumbs
 */
-@import url("_imports/tools/x-truncate.css");
+@import url("../tools/x-truncate.css");
 
 
 

--- a/src/lib/_imports/trumps/s-system-specs.css
+++ b/src/lib/_imports/trumps/s-system-specs.css
@@ -8,7 +8,7 @@ Styles for System Specifications content which assumes external code:
 
 Styleguide Trumps.Scopes.SystemSpecs
 */
-@import url("_imports/tools/media-queries.css");
+@import url("../tools/media-queries.css");
 
 
 


### PR DESCRIPTION
## Overview

Use relative paths, like [tup-ui].

<sup>These changes got merged to [tup-ui] `main` via https://github.com/TACC/tup-ui/pull/38. The original isolated change is some earlier [tup-ui] PR.</sup>

[tup-ui]: https://github.com/TACC/tup-ui/

## Related

None

## Changes

- Replace vague paths with relative paths.

## Testing

1. `npm ci`
2. `npm run build`
3. no errors

<sup>I tested this even further atop #34 via `npm run start` and `npm run build:demo`.</sup>

## UI

N/A
