### PR TITLE
chore: retire internal usage of cli

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+/** Build CSS using the Core-Styles API */
+
+const { buildStylesheets } = require('../src/main');
+
+buildStylesheets('src/lib/_imports/**/*!(README).css', './dist', {
+  baseMirrorDir: 'src/lib/_imports',
+});

--- a/bin/test.js
+++ b/bin/test.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+/** Test CSS plugins via the Core-Styles API */
+
+const { buildStylesheets } = require('../src/main');
+
+buildStylesheets('src/lib/_tests/**/*!(README).css', './dist', {
+  baseMirrorDir: 'src/lib',
+});

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "main": "src/main.js",
   "bin": "src/cli.js",
   "scripts": {
-    "build": "node src/cli.js build -i \"src/lib/_imports/**/*!(README).css\" -o \"./dist\" -m \"src/lib/_imports\"",
-    "test": "node src/cli.js build -i \"src/lib/_tests\" -o \"./dist\" -m \"src/lib\" && echo \"Test output at 'dist/_tests' (compare to test input)\"",
+    "build": "bin/build.js",
+    "test": "bin/test.js && echo \"Test output at 'dist/_tests' (compare to test input)\"",
     "prepublishOnly": "npm run build # && npm test && npm run lint"
   },
   "engines": {


### PR DESCRIPTION
## Overview

Replace core-styles build and test CLI commands with tiny scripts.

## Related

N/A

## Changes

- update `package.json` to run script
- add scripts that use module, not CLI 

## Testing

## Quickest Way

1. `cd libs/core-styles`
1. `npm ci`
1. `npm run build`, no errors
1. `npm run test`, no errors

## Longer Ways

- [How to Test Core Styles Build Chain, Quick Way](https://github.com/TACC/tup-ui/wiki/Test-Styles-Build-Chain,-Quick-Way)
- [Test Styles Build Chain, Long Way](https://github.com/TACC/tup-ui/wiki/Test-Styles-Build-Chain,-Long-Way)

## UI

N/A (no change expected)

## Notes

CMS no longer uses the CLI. Core-Styles itself need not use it either.

If CLI continues to prove unnecessary, delete it (and commander dependency).