### PR TITLE
feat(trumps): u-mailto-text-replace (for ecep 214)

### DIFF
--- a/src/lib/_imports/tools/x-mailto-text-replace.css
+++ b/src/lib/_imports/tools/x-mailto-text-replace.css
@@ -1,0 +1,18 @@
+/*
+Mailto Link Text Replacement
+
+Replace mailto link rendered text with virtual text from data-attributes
+
+Styleguide Tools.ExtendsAndMixins.MailtoTextReplace
+*/
+
+%x-mailto-text-replace {
+    visibility: hidden;
+    font-size: 0;
+}
+%x-mailto-text-replace::before {
+    display: inline;
+    content: attr(data-user) "@" attr(data-domain);
+    font-size: initial;
+    visibility: visible;
+}

--- a/src/lib/_imports/trumps/u-mailto-text-replace.css
+++ b/src/lib/_imports/trumps/u-mailto-text-replace.css
@@ -1,0 +1,10 @@
+.u-mailto-text-replace[data-user][data-domain] {
+    visibility: hidden;
+    font-size: 0;
+}
+.u-mailto-text-replace[data-user][data-domain]::before {
+    display: inline;
+    content: attr(data-user) "@" attr(data-domain);
+    font-size: initial;
+    visibility: visible;
+}

--- a/src/lib/_imports/trumps/u-mailto-text-replace.css
+++ b/src/lib/_imports/trumps/u-mailto-text-replace.css
@@ -1,10 +1,7 @@
+/* Create utility class from `x-mailto-text-replace` */
+
+@import url("@tacc/core-styles/src/lib/_imports/tools/x-mailto-text-replace.css");
+
 .u-mailto-text-replace[data-user][data-domain] {
-    visibility: hidden;
-    font-size: 0;
-}
-.u-mailto-text-replace[data-user][data-domain]::before {
-    display: inline;
-    content: attr(data-user) "@" attr(data-domain);
-    font-size: initial;
-    visibility: visible;
+    @extend %x-mailto-text-replace;
 }

--- a/src/lib/_imports/trumps/u-mailto-text-replace/u-mailto-text-replace.config.yml
+++ b/src/lib/_imports/trumps/u-mailto-text-replace/u-mailto-text-replace.config.yml
@@ -1,0 +1,7 @@
+label: Mailto Link Text Replacement
+notes: |-
+  Replaces the display text of an `<a href="mailto:…" data-user="bob" data-domain="">` link with the e-mail address constructed from the `data-user` and `data-domain` attributes.
+
+  This can be used to render an accurate e-mail that will not be recognized by a generic web scraper. The default display text should be an inaccurate e-mail address.
+
+  _To make sure link is accessible if CSS does not load, make it obvious to humans what part of an e-mail is inaccurate, e.g. `__REMOVE_THIS__`._

--- a/src/lib/_imports/trumps/u-mailto-text-replace/u-mailto-text-replace.hbs
+++ b/src/lib/_imports/trumps/u-mailto-text-replace/u-mailto-text-replace.hbs
@@ -1,0 +1,17 @@
+<dl>
+  <dt>No Attributes (thus no effect)</dt>
+  <dd>
+    <a href="mailto:__REMOVE_THIS__someone@any.domain.ext">
+      __REMOVE_THIS__someone@any.domain.ext
+    </a>
+  </dt>
+
+  <dt>Has Attributes (<code>data-user</code>, <code>data-domain</code>)</dt>
+  <dd>
+    <a
+      href="mailto:__REMOVE_THIS__someone@any.domain.ext"
+      data-domain="any.domain.ext" data-user="someone">
+      __REMOVE_THIS__someone@any.domain.ext
+    </a>
+  </dt>
+</dl>

--- a/src/lib/_imports/trumps/u-mailto-text-replace/u-mailto-text-replace.hbs
+++ b/src/lib/_imports/trumps/u-mailto-text-replace/u-mailto-text-replace.hbs
@@ -1,7 +1,9 @@
 <dl>
   <dt>No Attributes (thus no effect)</dt>
   <dd>
-    <a href="mailto:__REMOVE_THIS__someone@any.domain.ext">
+    <a
+      href="mailto:__REMOVE_THIS__someone@any.domain.ext"
+      class="u-mailto-text-replace">
       __REMOVE_THIS__someone@any.domain.ext
     </a>
   </dt>
@@ -10,7 +12,8 @@
   <dd>
     <a
       href="mailto:__REMOVE_THIS__someone@any.domain.ext"
-      data-domain="any.domain.ext" data-user="someone">
+      data-domain="any.domain.ext" data-user="someone"
+      class="u-mailto-text-replace">
       __REMOVE_THIS__someone@any.domain.ext
     </a>
   </dt>


### PR DESCRIPTION
## Overview

Replace text of `mailto:` links using data attributes (if available).

<details>

The details are added automatically by JavaScript from https://github.com/TACC/Core-CMS/pull/546.

</details>

## Related

- [ECEP-214](https://jira.tacc.utexas.edu/browse/ECEP-214)
- required by https://github.com/TACC/Core-CMS/pull/546

## Changes

- add new pattern `u-mailto-text-replace`

## Testing

### Core-Styles

0. `npm ci`
1. `npm run build`
2. `npm run start`
3. Navigate to Core > Trumps > Mailto Link Text Replacement.
4. Verify top link has no attributes and shows its actual link text.
5. Verify bottom link has data attributes and shows link text that is an altered e-mail address.

### Core-CMS

See https://github.com/TACC/Core-CMS/pull/546.

## UI

| Core Styles | Core CMS |
| - | - |
| ![Core-Styles](https://user-images.githubusercontent.com/62723358/186036055-0802b91a-bef8-40be-b71f-d5ff3906c2e0.png) | ![Core-CMS](https://user-images.githubusercontent.com/62723358/186036137-801e538e-e220-402a-b71d-4789af7e5110.png) |
