### PR TITLE
fix(c-button): fp-1791 auto width by default

### DIFF
--- a/src/lib/_imports/components/c-button.css
+++ b/src/lib/_imports/components/c-button.css
@@ -7,6 +7,7 @@
 
 
 
+
 /* Base */
 
 .c-button {
@@ -247,7 +248,9 @@ a.c-button {
   .c-button--width-long,
   .c-button--size-small,
   .c-button--as-link
-),
+) {
+  width: auto;
+}
 .c-button--width-short {
   width: var(--min-width);
 }

--- a/src/lib/_imports/components/c-button.css
+++ b/src/lib/_imports/components/c-button.css
@@ -21,7 +21,6 @@
   border-style: solid;
 
   font-weight: 500;
-  font-size: 0.75rem; /* 12px (10px design * 1.2 design-to-app ratio) */
 
   @extend %x-truncate--one-line;
 }


### PR DESCRIPTION
## Overview

Buttons should be automatic width by default.

## Related

- [FP-1791](https://jira.tacc.utexas.edu/browse/FP-1791)
- required by https://github.com/TACC/Core-CMS/pull/560

## Changes

- Do not default width to short.
- Do not set font size (let client do so, or not).

## Testing

Pages:
- https://apcd-qa.tacc.utexas.edu/register/request-to-submit
- https://apcd-qa.tacc.utexas.edu/register/request-to-submit-form

Steps:
1. Submit buttons are as wide as their text content (plus padding).
2. Submit buttons width is **not** fixed by a snippet.

## UI

Tested via consumer app; see https://github.com/TACC/Core-CMS/pull/560.