### PR TITLE
docs: tup-356 bootstrap preview & easy subdir var

### DIFF
--- a/src/lib/_imports/_bootstrap.css.hbs
+++ b/src/lib/_imports/_bootstrap.css.hbs
@@ -1,1 +1,0 @@
-<link id="css-bootstrap" rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">

--- a/src/lib/_imports/_preview.bootstrap.hbs
+++ b/src/lib/_imports/_preview.bootstrap.hbs
@@ -1,2 +1,6 @@
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+
+{{> @preview subdir=_target.context.subdir }}
+
 <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>

--- a/src/lib/_imports/_preview.hbs
+++ b/src/lib/_imports/_preview.hbs
@@ -2,7 +2,7 @@
 {{#unless styles.shouldSkipBase}}
   <link
     rel='stylesheet'
-    href='{{path "/{{ subdir }}/{{ _target.baseHandle }}.css"}}'
+    href='{{path "/{{ _target.context.subdir }}/{{ _target.baseHandle }}.css"}}'
   />
 {{/unless}}
 

--- a/src/lib/_imports/components/_components.config.yml
+++ b/src/lib/_imports/components/_components.config.yml
@@ -1,1 +1,2 @@
-preview: "@components.preview"
+context:
+  subdir: "components"

--- a/src/lib/_imports/components/_components.preview.hbs
+++ b/src/lib/_imports/components/_components.preview.hbs
@@ -1,1 +1,0 @@
-{{> @preview subdir="components" }}

--- a/src/lib/_imports/components/bootstrap/bootstrap.modal/bootstrap.modal.config.yml
+++ b/src/lib/_imports/components/bootstrap/bootstrap.modal/bootstrap.modal.config.yml
@@ -1,0 +1,1 @@
+preview: '@preview.bootstrap'

--- a/src/lib/_imports/components/bootstrap/bootstrap.modal/bootstrap.modal.hbs
+++ b/src/lib/_imports/components/bootstrap/bootstrap.modal/bootstrap.modal.hbs
@@ -1,4 +1,3 @@
-{{> @bootstrap.css }}
 <link rel="stylesheet" href="{{path '/components/c-button.css'}}" />
 
 <dl>
@@ -52,5 +51,3 @@
     </div>
   </dd>
 </dl>
-
-{{> @bootstrap.js }}


### PR DESCRIPTION
## Overview

DRY-er way to load bootstrap.

## Related

- [TUP-356](https://jira.tacc.utexas.edu/browse/TUP-356)

## Changes

- add bootstrap preview
- replace bootstrap css & js with preview load
- move subdir context to `components` config
- move subdir context to `trumps` config
- use bootstrap preview for bootstrap.modal pattern

## Testing & UI

See https://github.com/TACC/Core-Styles/pull/51.