### PR TITLE
docs(components): tup-356 bootstrap.container

### DIFF
--- a/src/lib/_imports/components/bootstrap.container.css
+++ b/src/lib/_imports/components/bootstrap.container.css
@@ -1,18 +1,10 @@
-/*
-Container (Bootstrap)
-
-Add to Bootstrap styles. See:
-
-- [Bootstrap Grid](https://getbootstrap.com/docs/4.0/layout/grid/)
-
-Styleguide Components.Bootstrap.Grid
-*/
+@import url("../settings/max-width.css");
 @import url("../tools/media-queries.css");
 
-@media (--x-wide-and-above) {
+@media (--xx-wide-and-above) {
   .container { max-width: var(--global-max-width--x-wide); }
 }
-@media (--xx-wide-and-above) {
+@media (--xxx-wide-and-above) {
   .container { max-width: var(--global-max-width--xx-wide); }
 }
 /* FAQ: We can do this, but Design does not want to stretch this wide */

--- a/src/lib/_imports/components/bootstrap/bootstrap.container/README.md
+++ b/src/lib/_imports/components/bootstrap/bootstrap.container/README.md
@@ -1,0 +1,54 @@
+To add wider [Bootstrap Grid](https://getbootstrap.com/docs/4.0/layout/grid/) containers.
+
+> **⚠️ Important**
+>
+> Because Bootstrap grid is so complex, only essential changes are recommended.
+
+> **ⓘ Notice**
+>
+> Bootstrap grid is powerful, popular, and present; so we do use it as our grid.
+
+<table style="caption-side: bottom;">
+  <caption>
+
+  The columns are added using TACC's `xx-wide` and `xxx-wide` custom properties and media queries.
+
+  <caption>
+  <thead>
+    <tr>
+      <th></th>
+      <th>Extra extra large <br>
+        <small>≥1680px</small>
+      </th>
+      <th>Extra extra extra large <br>
+        <small>≥1920px</small>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Max container width</td>
+      <td>1580px</td>
+      <td>1800px</td>
+    </tr>
+    <tr>
+      <td># of columns</td>
+      <td colspan="2">12</td>
+    </tr>
+    <tr>
+      <td>Gutter width</td>
+      <td colspan="2">30px (15px on each side of a column)</td>
+    </tr>
+    <tr>
+      <td>Nestable</td>
+      <td colspan="2">Yes</td>
+    </tr>
+  </tbody>
+</table>
+
+<script>
+/* To open external links in new window */
+Array.from(document.links)
+  .filter(link => link.hostname != window.location.hostname)
+  .forEach(link => link.target = '_blank');
+</script>

--- a/src/lib/_imports/components/bootstrap/bootstrap.container/bootstrap.container.config.yml
+++ b/src/lib/_imports/components/bootstrap/bootstrap.container/bootstrap.container.config.yml
@@ -1,0 +1,2 @@
+preview: '@preview.bootstrap'
+status: ready

--- a/src/lib/_imports/components/bootstrap/bootstrap.container/bootstrap.container.hbs
+++ b/src/lib/_imports/components/bootstrap/bootstrap.container/bootstrap.container.hbs
@@ -1,0 +1,4 @@
+<div class="container">
+  <h1>Lorem Ipsum</h1>
+  {{> @loremipsum }}
+</div>


### PR DESCRIPTION
## Overview

Document Bootstrap container.

## Related

- [TUP-356](https://jira.tacc.utexas.edu/browse/TUP-356)

## Changes

- document bootstrap.container pattern

## Testing

1. `npm start`
2. http://localhost:3000/components/detail/bootstrap.container

## UI

| 13" laptop (90% zoom)<br /><sub>1162px preview</sub> | 13" laptop (50% zoom)<br /><sub>1680px preview</sub> | 13" laptop (50% zoom)<br /><sub>1920px preview</sub> |
| - | - | - |
| <img width="1280" alt="tup-356-bootstrap-container" src="https://user-images.githubusercontent.com/62723358/200223072-9529e2e7-8351-456d-8915-3629bbfd256f.png"> | <img width="1280" alt="tup-356-bootstrap-container 1680" src="https://user-images.githubusercontent.com/62723358/200223080-5adb8d22-98e8-41c2-8e9a-665e1a89d6d2.png"> | <img width="1280" alt="tup-356-bootstrap-container 1920" src="https://user-images.githubusercontent.com/62723358/200223081-d62f1c5e-a138-4c53-974c-49f6c65f80f6.png"> |