### PR TITLE
fix(trumps, and unused): complex subdir var made easy

### DIFF
--- a/src/lib/_imports/elements/_elements.config.yml
+++ b/src/lib/_imports/elements/_elements.config.yml
@@ -1,1 +1,2 @@
-preview: "@elements.preview"
+context:
+  subdir: "elements"

--- a/src/lib/_imports/elements/_elements.preview.hbs
+++ b/src/lib/_imports/elements/_elements.preview.hbs
@@ -1,1 +1,0 @@
-{{> @preview subdir="elements" }}

--- a/src/lib/_imports/generics/_generics.config.yml
+++ b/src/lib/_imports/generics/_generics.config.yml
@@ -1,1 +1,2 @@
-preview: "@generics.preview"
+context:
+  subdir: "generics"

--- a/src/lib/_imports/generics/_generics.preview.hbs
+++ b/src/lib/_imports/generics/_generics.preview.hbs
@@ -1,1 +1,0 @@
-{{> @preview subdir="generics" }}

--- a/src/lib/_imports/objects/_objects.config.yml
+++ b/src/lib/_imports/objects/_objects.config.yml
@@ -1,1 +1,2 @@
-preview: "@objects.preview"
+context:
+  subdir: "objects"

--- a/src/lib/_imports/objects/_objects.preview.hbs
+++ b/src/lib/_imports/objects/_objects.preview.hbs
@@ -1,1 +1,0 @@
-{{> @preview subdir="objects" }}

--- a/src/lib/_imports/trumps/_trumps.config.yml
+++ b/src/lib/_imports/trumps/_trumps.config.yml
@@ -1,1 +1,2 @@
-preview: "@trumps.preview"
+context:
+  subdir: "trumps"

--- a/src/lib/_imports/trumps/_trumps.preview.hbs
+++ b/src/lib/_imports/trumps/_trumps.preview.hbs
@@ -1,1 +1,0 @@
-{{> @preview subdir="trumps" }}


### PR DESCRIPTION
## Overview

Simpler way to set `subdir` variable for preview templates.

## Related

- continues https://github.com/TACC/Core-Styles/pull/53

## Changes

- remove preview wrapper templates
- add preview variable (`subdir`) to directory configs

## Testing

1. `npm start`
2. Open "Trumps".
3. Confirm documented patterns work.

<sup>No other directories have documented patterns yet, and `components` was already tested in #53.</sup>

## UI

Skipped.
