### PR TITLE
fix: bootstrap form, use template not partials

### DIFF
--- a/src/lib/_imports/_partials/text-and-link.hbs
+++ b/src/lib/_imports/_partials/text-and-link.hbs
@@ -1,0 +1,1 @@
+<p>Pack my red box with five dozen quality jugs. A quick brown fox jumps over the <a href="#">lazy dog</a>. A waxy gent chuckled over my fab jazzy quips.</p>

--- a/src/lib/_imports/elements/links.css
+++ b/src/lib/_imports/elements/links.css
@@ -1,0 +1,17 @@
+@import url('../settings/color.css');
+@import url('../settings/border.css');
+
+a {
+  color: var(--global-color-link-on-light--normal);
+
+  text-decoration: none;
+  text-underline-offset: 0.2em;
+  text-decoration-thickness: var(--global-border-width--normal);
+}
+a:hover {
+  text-decoration-line: underline;
+  text-decoration-style: solid;
+}
+a:active {
+  text-decoration-style: dotted;
+}

--- a/src/lib/_imports/elements/links/docs.css
+++ b/src/lib/_imports/elements/links/docs.css
@@ -1,0 +1,6 @@
+/* This CSS is ONLY for the pattern library. It is NOT part of the pattern. */
+
+p {
+  margin: 10px;
+  max-width: 40ch; /* to wrap text so link is in middle of middle sentence */
+}

--- a/src/lib/_imports/elements/links/links.hbs
+++ b/src/lib/_imports/elements/links/links.hbs
@@ -1,0 +1,12 @@
+<link rel="stylesheet" href="{{path '/trumps/s-links-irregular.css'}}" />
+
+<dl>
+  <dt>Standard</dt>
+  <dd>
+    {{> @text-and-link }}
+  </dd>
+  <dt>Irregular</dt>
+  <dd class="s-links-irregular">
+    {{> @text-and-link }}
+  </dd>
+</dl>

--- a/src/lib/_imports/elements/links/links.hbs
+++ b/src/lib/_imports/elements/links/links.hbs
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="{{path '/trumps/s-links-irregular.css'}}" />
+<link rel="stylesheet" href="{{path '/trumps/s-irregular-links.css'}}" />
 
 <dl>
   <dt>Standard</dt>
@@ -6,7 +6,7 @@
     {{> @text-and-link }}
   </dd>
   <dt>Irregular</dt>
-  <dd class="s-links-irregular">
+  <dd class="s-irregular-links">
     {{> @text-and-link }}
   </dd>
 </dl>

--- a/src/lib/_imports/elements/links/readme.md
+++ b/src/lib/_imports/elements/links/readme.md
@@ -1,0 +1,8 @@
+The [`<a>` anchor element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a).
+
+<script>
+/* To open external links in new window */
+Array.from(document.links)
+  .filter(link => link.hostname != window.location.hostname)
+  .forEach(link => link.target = '_blank');
+</script>

--- a/src/lib/_imports/trumps/s-links-irregular.css
+++ b/src/lib/_imports/trumps/s-links-irregular.css
@@ -1,0 +1,9 @@
+.s-links-irregular a {
+  text-decoration-line: underline;
+}
+.s-links-irregular a:hover {
+  text-decoration-style: dashed;
+}
+.s-links-irregular a:active {
+  text-decoration-style: dotted;
+}

--- a/src/lib/_imports/trumps/s-links-irregular.css
+++ b/src/lib/_imports/trumps/s-links-irregular.css
@@ -1,9 +1,9 @@
-.s-links-irregular a {
+.s-irregular-links a {
   text-decoration-line: underline;
 }
-.s-links-irregular a:hover {
+.s-irregular-links a:hover {
   text-decoration-style: dashed;
 }
-.s-links-irregular a:active {
+.s-irregular-links a:active {
   text-decoration-style: dotted;
 }

--- a/src/lib/_imports/trumps/s-links-irregular/config.yml
+++ b/src/lib/_imports/trumps/s-links-irregular/config.yml
@@ -1,0 +1,1 @@
+label: Links (Irregular)

--- a/src/lib/_imports/trumps/s-links-irregular/readme.md
+++ b/src/lib/_imports/trumps/s-links-irregular/readme.md
@@ -1,0 +1,29 @@
+This allows us to satisfy clients who strongly prefer [standard CMS links]¹ are underlined.
+
+> **⚠️ Warning**
+>
+> Do **not** add to `<body>` tag, otherwise header may adversely inherit styles.
+
+**Instructions**
+
+1. Add `s-links-irregular` class to an ancestor element.
+
+**Examples**
+
+```
+<main class="s-links-irregular">
+    ... <a href="...">Click me</a> ...
+</main>
+```
+
+```
+<section class="some-unique-content s-links-irregular">
+    ... <a href="...">Click me</a> ...
+</section>
+```
+
+---
+
+<small>¹ The [standard CMS links] do meet “WCAG 2.0 Level AA” link contrast.</small>
+
+[standard CMS links]: /components/detail/links.cms

--- a/src/lib/_imports/trumps/s-links-irregular/readme.md
+++ b/src/lib/_imports/trumps/s-links-irregular/readme.md
@@ -6,18 +6,18 @@ This allows us to satisfy clients who strongly prefer [standard CMS links]¹ are
 
 **Instructions**
 
-1. Add `s-links-irregular` class to an ancestor element.
+1. Add `s-irregular-links` class to an ancestor element.
 
 **Examples**
 
 ```
-<main class="s-links-irregular">
+<main class="s-irregular-links">
     ... <a href="...">Click me</a> ...
 </main>
 ```
 
 ```
-<section class="some-unique-content s-links-irregular">
+<section class="some-unique-content s-irregular-links">
     ... <a href="...">Click me</a> ...
 </section>
 ```

--- a/src/lib/_imports/trumps/s-links-irregular/s-irregular-links.hbs
+++ b/src/lib/_imports/trumps/s-links-irregular/s-irregular-links.hbs
@@ -1,6 +1,9 @@
 <link rel="stylesheet" href="{{path '/elements/links.cms.css'}}" />
 <link rel="stylesheet" href="{{path '/elements/links.cms/links.cms_docs.css'}}" />
 
-<section class="s-links-irregular">
+<dl>
+  <dt>Irregular</dt>
+  <dd class="s-irregular-links">
     {{> @text-and-link }}
-</section>
+  </dd>
+</dl>

--- a/src/lib/_imports/trumps/s-links-irregular/s-links-irregular.hbs
+++ b/src/lib/_imports/trumps/s-links-irregular/s-links-irregular.hbs
@@ -1,0 +1,6 @@
+<link rel="stylesheet" href="{{path '/elements/links.cms.css'}}" />
+<link rel="stylesheet" href="{{path '/elements/links.cms/links.cms_docs.css'}}" />
+
+<section class="s-links-irregular">
+    {{> @text-and-link }}
+</section>


### PR DESCRIPTION
## Overview

Add link pattern.

## Related

- [TUP-355](https://jira.tacc.utexas.edu/browse/TUP-355)

## Changes

- add `elements/links`
- add `trumps/irregular-links`

## Testing

1. `npm run build`
2. `npm start`
3. http://localhost:3000/components/detail/links
4. Review "Elements" > "Links".
4. Review "Trumps" > "Links (Irregular)".

## UI

https://user-images.githubusercontent.com/62723358/200469807-9adcc2ed-cac0-44df-8a3e-777ecb329fa5.mov
