### PR TITLE
feat(c-button): do not show <a> tag button for `--as-link`

### DIFF
--- a/src/lib/_imports/components/c-button/c-button.config.yml
+++ b/src/lib/_imports/components/c-button/c-button.config.yml
@@ -1,4 +1,5 @@
 context:
+  showLinkTag: true
   supports:
     states: true
     icons: true
@@ -27,6 +28,7 @@ variants:
   - name: as-link
     notes: For a button that resembles a link
     context:
+      showLinkTag: false
       supports:
         width: false
         size: false

--- a/src/lib/_imports/components/c-button/c-button.config.yml
+++ b/src/lib/_imports/components/c-button/c-button.config.yml
@@ -1,11 +1,11 @@
 context:
-  showLinkTag: true
   supports:
     states: true
     icons: true
     width: true
     size: true
     size-small: true
+    link-tag: true
 variants:
   # type
   - name: default
@@ -28,10 +28,10 @@ variants:
   - name: as-link
     notes: For a button that resembles a link
     context:
-      showLinkTag: false
       supports:
         width: false
         size: false
+        link-tag: false
   # state
   - name: is-busy
     notes: For a button whose being clicked started an incomplete process (should have `disabled` attribute)

--- a/src/lib/_imports/components/c-button/c-button.hbs
+++ b/src/lib/_imports/components/c-button/c-button.hbs
@@ -22,7 +22,7 @@
       </button>
     </dd>
 
-    {{#if showLinkTag}}
+    {{#if supports.link-tag}}
     <dt><code>&lt;a&gt;</code></dt>
     <dd>
       <a href="#" class="c-button c-button--{{this._self.name}} c-button--secondary"
@@ -62,7 +62,7 @@
         <span class="c-button__text">--is-busy</span>
     </dd>
 
-    {{#if showLinkTag}}
+    {{#if supports.link-tag}}
     <dt><code>&lt;a&gt;</code></dt>
     <dd>
       <a href="#" class="c-button c-button--{{this._self.name}}
@@ -100,7 +100,7 @@
         <i class="c-button__icon--after" aria-description="exit page">X</i>
     </dd>
 
-    {{#if showLinkTag}}
+    {{#if supports.link-tag}}
     <dt><code>&lt;a&gt;</code></dt>
     <dd>
       <a href="#" class="c-button c-button--{{this._self.name}}
@@ -141,7 +141,7 @@
         <span class="c-button__text">--width-long</span>
     </dd>
 
-    {{#if showLinkTag}}
+    {{#if supports.link-tag}}
     <dt><code>&lt;a&gt;</code></dt>
     <dd>
       <a href="#" class="c-button c-button--{{this._self.name}}
@@ -176,7 +176,7 @@
         </button>
       </dd>
 
-      {{#if showLinkTag}}
+      {{#if supports.link-tag}}
       <dt><code>&lt;a&gt;</code></dt>
       <dd>
         <a href="#" class="c-button c-button--{{this._self.name}} c-button--size-small

--- a/src/lib/_imports/components/c-button/c-button.hbs
+++ b/src/lib/_imports/components/c-button/c-button.hbs
@@ -22,6 +22,7 @@
       </button>
     </dd>
 
+    {{#if showLinkTag}}
     <dt><code>&lt;a&gt;</code></dt>
     <dd>
       <a href="#" class="c-button c-button--{{this._self.name}} c-button--secondary"
@@ -41,6 +42,7 @@
         <span class="c-button__text">--tertiary</span>
       </a>
     </dd>
+    {{/if}}
   </dl><dd>
   {{/if}}
 
@@ -60,6 +62,7 @@
         <span class="c-button__text">--is-busy</span>
     </dd>
 
+    {{#if showLinkTag}}
     <dt><code>&lt;a&gt;</code></dt>
     <dd>
       <a href="#" class="c-button c-button--{{this._self.name}}
@@ -73,6 +76,7 @@
         <span class="c-button__text">--is-busy</span>
       </a>
     </dd>
+    {{/if}}
   </dl><dd>
   {{/if}}
 
@@ -96,6 +100,7 @@
         <i class="c-button__icon--after" aria-description="exit page">X</i>
     </dd>
 
+    {{#if showLinkTag}}
     <dt><code>&lt;a&gt;</code></dt>
     <dd>
       <a href="#" class="c-button c-button--{{this._self.name}}
@@ -113,6 +118,7 @@
         <i class="c-button__icon--after" aria-description="exit page">X</i>
       </a>
     </dd>
+    {{/if}}
   </dl><dd>
   {{/if}}
 
@@ -135,6 +141,7 @@
         <span class="c-button__text">--width-long</span>
     </dd>
 
+    {{#if showLinkTag}}
     <dt><code>&lt;a&gt;</code></dt>
     <dd>
       <a href="#" class="c-button c-button--{{this._self.name}}
@@ -151,6 +158,7 @@
         <span class="c-button__text">--width-long</span>
       </a>
     </dd>
+    {{/if}}
   </dl><dd>
   {{/if}}
 
@@ -168,6 +176,7 @@
         </button>
       </dd>
 
+      {{#if showLinkTag}}
       <dt><code>&lt;a&gt;</code></dt>
       <dd>
         <a href="#" class="c-button c-button--{{this._self.name}} c-button--size-small
@@ -176,6 +185,7 @@
           <span class="c-button__text">--size-small</span>
         </a>
       </dd>
+      {{/if}}
     </dl>
     {{else}}
     <small>(no small size allowed)</small>


### PR DESCRIPTION
## Overview

Show `<a>` tag use of `c-button`, unless button is type `c-button--as-link`.

## Related

N/A

## Changes

- add `supports.link-tag` context boolean
- use new context boolean to show `<a>` tag for most `c-button` states

## Testing

1. `git checkout`
2. `npm run build:css`
3. `npm start`
4. Navigate to [Components > C-Button > Primary](http://localhost:3000/components/detail/c-button--primary).
5. Verify `<a>` examples are shown.
6. Navigate to [Components > C-Button > As Link](http://localhost:3000/components/detail/c-button--as-link).
7. Verify `<a>` examples are **not** shown.

## UI

| Primary | As Link |
| - | - |
| ![Primary](https://user-images.githubusercontent.com/62723358/201388337-d7ddd2ff-4c74-48b3-9280-fccc6106b473.png) | ![As Link](https://user-images.githubusercontent.com/62723358/201388332-1894bd01-b8d5-4aec-a6f8-24040573f6ef.png) |