### PR TITLE
feat: x-link, used by c-button--as-link & links

### DIFF
--- a/src/lib/_imports/_partials/text-and-button-as-link.hbs
+++ b/src/lib/_imports/_partials/text-and-button-as-link.hbs
@@ -1,0 +1,1 @@
+<p>Pack my red box with five dozen quality jugs. A quick brown fox jumps over the <button class="c-button c-button--as-link">lazy dog</button>. A waxy gent chuckled over my fab jazzy quips.</p>

--- a/src/lib/_imports/components/c-button.css
+++ b/src/lib/_imports/components/c-button.css
@@ -1,4 +1,5 @@
 @import url("../tools/x-truncate.css");
+@import url('../tools/x-link.css');
 
 @custom-selector :--disabled
   :disabled,
@@ -218,14 +219,19 @@ a.c-button {
 /* Modifiers: Types: As Link */
 
 .c-button--as-link {
-  color: var(--global-color-accent--normal);
+  @extend .x-link;
 
   background: unset;
   border: unset;
   padding-inline: unset;
+
+  font-size: inherit;
 }
-.c-button--as-link:not(:--disabled):hover {
-  text-decoration: underline;
+.c-button--as-link:where(:not(:--disabled)):hover {
+  @extend .x-link--hover;
+}
+.c-button--as-link:active {
+  @extend .x-link--active;
 }
 
 /* Modifiers: Types: Is Busy */

--- a/src/lib/_imports/elements/links.css
+++ b/src/lib/_imports/elements/links.css
@@ -1,17 +1,11 @@
-@import url('../settings/color.css');
-@import url('../settings/border.css');
+@import url('../tools/x-link.css');
 
 a {
-  color: var(--global-color-link-on-light--normal);
-
-  text-decoration: none;
-  text-underline-offset: 0.2em;
-  text-decoration-thickness: var(--global-border-width--normal);
+  @extend .x-link;
 }
 a:hover {
-  text-decoration-line: underline;
-  text-decoration-style: solid;
+  @extend .x-link--hover;
 }
 a:active {
-  text-decoration-style: dotted;
+  @extend .x-link--active;
 }

--- a/src/lib/_imports/tools/_tools.config.yml
+++ b/src/lib/_imports/tools/_tools.config.yml
@@ -1,0 +1,2 @@
+context:
+  subdir: "tools"

--- a/src/lib/_imports/tools/x-link.css
+++ b/src/lib/_imports/tools/x-link.css
@@ -1,0 +1,18 @@
+@import url('../settings/color.css');
+@import url('../settings/border.css');
+
+.x-link {
+  color: var(--global-color-link-on-light--normal);
+
+  text-decoration: none;
+  text-underline-offset: 0.2em;
+  text-decoration-thickness: var(--global-border-width--normal);
+}
+.x-link--hover {
+  text-decoration-line: underline;
+  text-decoration-style: solid;
+}
+.x-link--active {
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+}

--- a/src/lib/_imports/tools/x-link/docs.css
+++ b/src/lib/_imports/tools/x-link/docs.css
@@ -1,0 +1,6 @@
+/* This CSS is ONLY for the pattern library. It is NOT part of the pattern. */
+
+p {
+  margin: 10px;
+  max-width: 40ch; /* to wrap text so link is in middle of middle sentence */
+}

--- a/src/lib/_imports/tools/x-link/readme.md
+++ b/src/lib/_imports/tools/x-link/readme.md
@@ -1,0 +1,14 @@
+UI states of [`<a>` anchor element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) as mixins.
+
+| Mixin | Description
+| - | -
+| `.x-link`         | default state
+| `.x-link--hover`  | `:hover` state
+| `.x-link--active` | `:active` (click) state
+
+<script>
+/* To open external links in new window */
+Array.from(document.links)
+  .filter(link => link.hostname != window.location.hostname)
+  .forEach(link => link.target = '_blank');
+</script>

--- a/src/lib/_imports/tools/x-link/x-link.hbs
+++ b/src/lib/_imports/tools/x-link/x-link.hbs
@@ -1,0 +1,3 @@
+<link rel="stylesheet" href="{{path '/elements/links.css'}}" />
+
+{{> @links }}

--- a/src/lib/_imports/trumps/s-irregular-links.css
+++ b/src/lib/_imports/trumps/s-irregular-links.css
@@ -7,3 +7,13 @@
 .s-irregular-links a:active {
   text-decoration-style: dotted;
 }
+
+.s-irregular-links .c-button--as-link {
+  text-decoration-line: underline;
+}
+.s-irregular-links .c-button--as-link:hover {
+  text-decoration-style: dashed;
+}
+.s-irregular-links .c-button--as-link:active {
+  text-decoration-style: dotted;
+}

--- a/src/lib/_imports/trumps/s-irregular-links/config.yml
+++ b/src/lib/_imports/trumps/s-irregular-links/config.yml
@@ -1,1 +1,8 @@
+context:
+  supportStyles:
+    - /elements/links.css
+    - /elements/links/docs.css
+    - /components/c-button.css
 label: Links (Irregular)
+variants:
+  - name: default

--- a/src/lib/_imports/trumps/s-irregular-links/s-irregular-links.hbs
+++ b/src/lib/_imports/trumps/s-irregular-links/s-irregular-links.hbs
@@ -1,9 +1,10 @@
-<link rel="stylesheet" href="{{path '/elements/links.css'}}" />
-<link rel="stylesheet" href="{{path '/elements/links/docs.css'}}" />
-
 <dl>
-  <dt>Irregular</dt>
+  <dt>Links</dt>
   <dd class="s-irregular-links">
     {{> @text-and-link }}
+  </dd>
+  <dt>Buttons as Links</dt>
+  <dd class="s-irregular-links">
+    {{> @text-and-button-as-link }}
   </dd>
 </dl>


### PR DESCRIPTION
## Overview

Create `x-link` mixin so that `components/c-button--as-link` and `element/links` can share styles.

## Related

N/A

## Changes

- feat: add `text-and-button-as-link` partial
- feat: change `c-button--as-link` to extend `x-link`
- feat: change `a` to extend `x-link`
- feat: add `tools/` as Tools section
- feat: add `x-link` mixin
- feat: add `c-button`s to `s-irregular-links`

## Testing & UI

1. `npm run build`
2. `npm start`
3. Verify link states match on the following pages:

    | <sub>Components</sub><br />C Button (As Link) | <sub>Elements</sub><br />Links | <sub>Tools</sub><br />X Link | <sub>Trumps</sub><br />Links (Irregular) |
    | - | - | - | - |
    | ![C Button As Link](https://user-images.githubusercontent.com/62723358/201391999-37068acf-82ff-4681-b582-a54bc75590c0.png) | ![Links](https://user-images.githubusercontent.com/62723358/201391997-637e38b5-17d8-46f6-ad4c-b16c792f899a.png) | ![X Link](https://user-images.githubusercontent.com/62723358/201391998-15333d4e-8bcf-4e9b-9ea4-9baf4d00929b.png) | ![Links (Irregular)](https://user-images.githubusercontent.com/62723358/201391994-96d8095c-75ee-4b3e-b857-7290afcd3fa1.png) | 

    https://user-images.githubusercontent.com/62723358/201392001-349bee10-243d-4420-a3c8-1eaf335c15c4.mov

## Notes

Known (but only tangentially-related) issue is that the "Mailto Link Text Replacement" is not using link styles.