### PR TITLE
fix: fp-1828 s-affixed-input-wrapper fallback

### DIFF
--- a/src/lib/_imports/trumps/s-affixed-input-wrapper.css
+++ b/src/lib/_imports/trumps/s-affixed-input-wrapper.css
@@ -20,11 +20,21 @@
     "help help"
     "error error";
 }
-.s-affixed-input-wrapper:has(.s-affixed-input-wrapper__prefix) {
-  --input-row: "prefix input";
+@supports selector(:has(table)) {
+  .s-affixed-input-wrapper:has(.s-affixed-input-wrapper__prefix) {
+    --input-row: "prefix input";
+  }
+  .s-affixed-input-wrapper:has(.s-affixed-input-wrapper__suffix) {
+    --input-row: "input suffix";
+  }
 }
-.s-affixed-input-wrapper:has(.s-affixed-input-wrapper__suffix) {
-  --input-row: "input suffix";
+@supports not selector(:has(table)) {
+  .s-affixed-input-wrapper--prefix {
+    --input-row: "prefix input";
+  }
+  .s-affixed-input-wrapper--suffix {
+    --input-row: "input suffix";
+  }
 }
 .s-affixed-input-wrapper label { grid-area: label; }
 .s-affixed-input-wrapper input { grid-area: input; }

--- a/src/lib/_imports/trumps/s-affixed-input-wrapper.css
+++ b/src/lib/_imports/trumps/s-affixed-input-wrapper.css
@@ -20,7 +20,7 @@
     "help help"
     "error error";
 }
-@supports selector(:has(table)) {
+@supports selector(:has(*)) {
   .s-affixed-input-wrapper:has(.s-affixed-input-wrapper__prefix) {
     --input-row: "prefix input";
   }
@@ -28,7 +28,7 @@
     --input-row: "input suffix";
   }
 }
-@supports not selector(:has(table)) {
+@supports not selector(:has(*)) {
   .s-affixed-input-wrapper--prefix {
     --input-row: "prefix input";
   }

--- a/src/lib/_imports/trumps/s-affixed-input-wrapper/s-affixed-input-wrapper.hbs
+++ b/src/lib/_imports/trumps/s-affixed-input-wrapper/s-affixed-input-wrapper.hbs
@@ -2,7 +2,7 @@
 
 <dl>
   <dt>Prefix</dt>
-  <dd class="s-affixed-input-wrapper">
+  <dd class="s-affixed-input-wrapper s-affixed-input-wrapper--prefix">
     <label for="field-dollars">How many dollars to you have?</label>
 
     <span class="s-affixed-input-wrapper__prefix">$</span>
@@ -16,7 +16,7 @@
     />
   </dd>
   <dt>Suffix</dt>
-  <dd class="s-affixed-input-wrapper">
+  <dd class="s-affixed-input-wrapper s-affixed-input-wrapper--suffix">
     <label for="field-usd">How many US Dollars to you have?</label>
 
     <input


### PR DESCRIPTION
## Overview

Add `s-affixed-input-wrapper` modifiers `--prefix` and `--suffix`.﹡

<sub>﹡ Because Firefox does not support `:has(…)` by default yet.</sub>

## Related

- fixes [FP-1828](https://jira.tacc.utexas.edu/browse/FP-1828)
- required by https://github.com/TACC/Core-CMS-Resources/pull/___

## Changes

- `s-affixed-input-wrapper--prefix`
- `s-affixed-input-wrapper--suffix`
- use modifiers if browser does not support `:has(*)`

## Testing

Pattern URL: http://localhost:3000/components/detail/s-affixed-input-wrapper

1. In **Firefox**, open pattern.
2. **Verify** dollar signs are accurately placed.[^1]
3. (optional) Notice dollar sign position is applied via `--prefix` and `--suffix`.
4. In **Edge** or **Chrome**, open pattern.
5. **Verify** dollar signs are accurately placed.[^1]
6. (optional) Notice dollar sign position is applied via `has(...)`.

## UI

### Which Code is Used

| Chromium **After** Fix | Firefox **After** Fix |
| - | - |
| <img width="1392" alt="Chromium After Fix Using Has Selector" src="https://user-images.githubusercontent.com/62723358/201499352-5ca2fe19-caec-4b92-988e-8cfffcc7c85d.png"> | <img width="1392" alt="Firefox After Fix Using Modifier Class" src="https://user-images.githubusercontent.com/62723358/201499353-95ec9fa9-e90b-48c4-804d-e1000902d047.png"> |

### Fix: Before & After

| Firefox **Before** Fix | Firefox **After** Fix |
| - | - |
| <img width="1392" alt="Firefox Before Fix" src="https://user-images.githubusercontent.com/62723358/201499355-51412c09-7134-4d94-a3be-fdadee47ed9c.png"> | <img width="1392" alt="Firefox After Fix" src="https://user-images.githubusercontent.com/62723358/201499354-97108533-e9c6-4d29-ad81-beb4914bff85.png"> |

[^1]: The suffix dollar sign is overlapping the number field triangle buttons. This is a known issue (documented in the pattern itself). No CMS yet uses the suffix feature.