### PR TITLE
docs: nest demo assets in `/assets` directory

### DIFF
--- a/fractal.config.js
+++ b/fractal.config.js
@@ -32,11 +32,11 @@ fractal.components.set('default.context', {
   styles: {
     internal: {
       local: [
-        '/settings/border.css',
-        '/settings/color.css',
-        '/settings/font.css',
-        '/settings/max-width.css',
-        '/settings/space.css',
+        '/assets/settings/border.css',
+        '/assets/settings/color.css',
+        '/assets/settings/font.css',
+        '/assets/settings/max-width.css',
+        '/assets/settings/space.css',
       ],
     },
   },
@@ -45,6 +45,7 @@ fractal.components.set('default.context', {
 // Set website paths
 fractal.docs.set('path', __dirname + '/docs');
 fractal.web.set('static.path', __dirname + '/dist');
+fractal.web.set('static.mount', 'assets');
 fractal.web.set('builder.dest', __dirname + '/demo');
 
 // Customize theme

--- a/src/lib/_imports/_partials/cms.css.hbs
+++ b/src/lib/_imports/_partials/cms.css.hbs
@@ -1,3 +1,3 @@
 {{!-- To render atop styles dependent on CMS e.g. `rem` font size --}}
-{{!-- SEE: src/lib/_imports/elements/html-elements.cms.css --}}
-<link rel='stylesheet' href='{{path "/elements/html-elements.cms.css"}}' />
+{{!-- SEE: src/lib/_imports/assets/elements/html-elements.cms.css --}}
+<link rel='stylesheet' href='{{path "/assets/elements/html-elements.cms.css"}}' />

--- a/src/lib/_imports/_preview.hbs
+++ b/src/lib/_imports/_preview.hbs
@@ -10,7 +10,7 @@
 {{#unless styles.shouldSkipBase}}
   <link
     rel='stylesheet'
-    href='{{path "/{{ _target.context.subdir }}/{{ _target.baseHandle }}.css"}}'
+    href='{{path "/assets/{{ _target.context.subdir }}/{{ _target.baseHandle }}.css"}}'
   />
 {{/unless}}
 

--- a/src/lib/_imports/components/bootstrap.css
+++ b/src/lib/_imports/components/bootstrap.css
@@ -1,0 +1,3 @@
+/* EMPTY ON PURPOSE! */
+/* FAQ: Created to avoid 404 in pattern library. */
+/* WARNING: This file should never have styles. */

--- a/src/lib/_imports/components/bootstrap/bootstrap--form.hbs
+++ b/src/lib/_imports/components/bootstrap/bootstrap--form.hbs
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="{{path '/components/c-button.css'}}" />
+<link rel="stylesheet" href="{{path '/assets/components/c-button.css'}}" />
 
 <form>
   <label for="field-name">Name</label>

--- a/src/lib/_imports/components/bootstrap/bootstrap--modal.hbs
+++ b/src/lib/_imports/components/bootstrap/bootstrap--modal.hbs
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="{{path '/components/c-button.css'}}" />
+<link rel="stylesheet" href="{{path '/assets/components/c-button.css'}}" />
 
 <dl>
   <dt>Dynamic</dt>

--- a/src/lib/_imports/elements/links/links.hbs
+++ b/src/lib/_imports/elements/links/links.hbs
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="{{path '/trumps/s-irregular-links.css'}}" />
+<link rel="stylesheet" href="{{path '/assets/trumps/s-irregular-links.css'}}" />
 
 <dl>
   <dt>Standard</dt>

--- a/src/lib/_imports/elements/table/config.yml
+++ b/src/lib/_imports/elements/table/config.yml
@@ -1,8 +1,8 @@
 preview: '@preview.cms'
 context:
   supportStyles:
-    - /elements/links.css
-    - /components/c-button.css
+    - /assets/elements/links.css
+    - /assets/components/c-button.css
 variants:
   - name: default
     label: Basic

--- a/src/lib/_imports/tools/x-link/x-link.hbs
+++ b/src/lib/_imports/tools/x-link/x-link.hbs
@@ -1,3 +1,1 @@
-<link rel="stylesheet" href="{{path '/elements/links.css'}}" />
-
 {{> @links }}

--- a/src/lib/_imports/trumps/s-affixed-input-wrapper/s-affixed-input-wrapper.hbs
+++ b/src/lib/_imports/trumps/s-affixed-input-wrapper/s-affixed-input-wrapper.hbs
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="{{path '/elements/form.cms.css'}}" />
+<link rel="stylesheet" href="{{path '/assets/elements/form.cms.css'}}" />
 
 <dl>
   <dt>Prefix</dt>

--- a/src/lib/_imports/trumps/s-irregular-links/config.yml
+++ b/src/lib/_imports/trumps/s-irregular-links/config.yml
@@ -1,8 +1,8 @@
 context:
   supportStyles:
-    - /elements/links.css
-    - /elements/links/docs.css
-    - /components/c-button.css
+    - /assets/elements/links.css
+    - /assets/elements/links/docs.css
+    - /assets/components/c-button.css
 label: Links (Irregular)
 variants:
   - name: default

--- a/src/lib/_imports/trumps/u-mailto-text-replace/config.yml
+++ b/src/lib/_imports/trumps/u-mailto-text-replace/config.yml
@@ -1,4 +1,4 @@
 label: Mailto Link Text Replacement
 context:
   supportStyles:
-    - /elements/links.css
+    - /assets/elements/links.css


### PR DESCRIPTION
## Overview

Nest demo `.css` files in `/assets` directory.

## Related

N/A

## Changes

- mount web static as `/assets`
- load docs assets from `/assets`

## Testing

1. Load all pages of pattern library.
2. Verify all stylesheets load.
    <sup>You can use Developer Tools "Network" tab.</sup>

## UI

Skipped.