### PR TITLE
fix(fonts): fp-1891 wrong path to regular italic

### DIFF
--- a/src/lib/_imports/generics/fonts.css
+++ b/src/lib/_imports/generics/fonts.css
@@ -30,7 +30,7 @@ Styleguide Generics.Fonts
 }
 @font-face {
   font-family: 'Benton Sans';
-  src: url("../../BentonSans-RegularItalic.otf") format("opentype");
+  src: url("../../fonts/BentonSans-RegularItalic.otf") format("opentype");
   font-weight: 400;
   font-style: italic;
   font-display: swap;


### PR DESCRIPTION
## Overview / Changes

Hotfix for bad path in #71.

## Related

- [FP-1891](https://jira.tacc.utexas.edu/browse/FP-1891)
- fixes #71

## Testing & UI

Skipped.