### PR TITLE
feat(o-fixed-header-table): wrapper vs non-wrapper usage

### DIFF
--- a/dist/objects/o-fixed-header-table/demo.css
+++ b/dist/objects/o-fixed-header-table/demo.css
@@ -1,1 +1,1 @@
-/*! @tacc/core-styles 1.0.0+ | MIT | github.com/TACC/Core-Styles */div{height:100%;max-height:300px;overflow-y:scroll}body{align-items:center;display:grid;justify-items:center}
+/*! @tacc/core-styles 1.0.0+ | MIT | github.com/TACC/Core-Styles */dd{height:100%;max-height:300px;overflow-y:scroll}body{align-items:center;display:grid;justify-items:center}

--- a/src/lib/_imports/elements/table/table.hbs
+++ b/src/lib/_imports/elements/table/table.hbs
@@ -1,4 +1,4 @@
-<table {{#if data.has-table }}class="has-table"{{/if}}>
+<table class="{{#if data.has-table }}has-table{{/if}} {{#if class }}{{ class }}{{/if}}">
   {{#if caption }}
   <caption>{{{ caption }}}</catpion>
   {{/if}}

--- a/src/lib/_imports/objects/o-fixed-header-table/demo.css
+++ b/src/lib/_imports/objects/o-fixed-header-table/demo.css
@@ -12,7 +12,6 @@ div {
 
 /* To illustrate that scrollbar is for the table (not the window) */
 body {
-  display: grid;
-  align-items: center;
-  justify-items: center;
+  display: flex;
+  flex-wrap: wrap;
 }

--- a/src/lib/_imports/objects/o-fixed-header-table/o-fixed-header-table.hbs
+++ b/src/lib/_imports/objects/o-fixed-header-table/o-fixed-header-table.hbs
@@ -1,12 +1,16 @@
 <dl>
   <dt>Class Directly on Table</dt>
   <dd>
-    {{> @table data=data caption="Header stays pinned top top of container on scroll." class="o-fixed-header-table" }}
+    <div>
+      {{> @table data=data caption="Header stays pinned top top of container on scroll." class="o-fixed-header-table" }}
+    </div>
   </dd>
 </dl>
 <dl>
   <dt>Class on Table Wrapper</dt>
-  <dd class="o-fixed-header-table">
-    {{> @table data=data caption="Header stays pinned top top of container on scroll." }}
+  <dd>
+    <div class="o-fixed-header-table">
+      {{> @table data=data caption="Header stays pinned top top of container on scroll." }}
+    </div>
   </dd>
 </dl>

--- a/src/lib/_imports/objects/o-fixed-header-table/o-fixed-header-table.hbs
+++ b/src/lib/_imports/objects/o-fixed-header-table/o-fixed-header-table.hbs
@@ -1,3 +1,12 @@
-<div class="o-fixed-header-table">
-  {{> @table data=data caption="Header stays pinned top top of container on scroll." }}
-</div>
+<dl>
+  <dt>Class Directly on Table</dt>
+  <dd>
+    {{> @table data=data caption="Header stays pinned top top of container on scroll." class="o-fixed-header-table" }}
+  </dd>
+</dl>
+<dl>
+  <dt>Class on Table Wrapper</dt>
+  <dd class="o-fixed-header-table">
+    {{> @table data=data caption="Header stays pinned top top of container on scroll." }}
+  </dd>
+</dl>

--- a/src/lib/_imports/objects/o-fixed-header-table/readme.md
+++ b/src/lib/_imports/objects/o-fixed-header-table/readme.md
@@ -1,6 +1,8 @@
 A [table]({{path './table' }}) with its header pinned during vertical scroll.
 
-_Do not add the class to a wrapper unless your use case demands one. Do not create a wrapper unless your use case demands it. (One may already exist.)_
+> **⚠️ Important**
+>
+> The `<div>` wrapper is **not** required. Do not add unless your use case demands one.
 
 > **?&#x20DD; Explanation**
 >

--- a/src/lib/_imports/objects/o-fixed-header-table/readme.md
+++ b/src/lib/_imports/objects/o-fixed-header-table/readme.md
@@ -1,5 +1,7 @@
 A [table]({{path './table' }}) with its header pinned during vertical scroll.
 
+_Do not add the class to a wrapper unless your use case demands one. Do not create a wrapper unless your use case demands it. (One may already exist.)_
+
 > **?&#x20DD; Explanation**
 >
 > [You can’t position: sticky; a `<thead>`. Nor a `<tr>`. But you can sticky a `<th>`…][source]


### PR DESCRIPTION
## Overview

Show that `o-fixed-header-table` can be used directly on table (or on wrapper).

## Related

N/A

## Changes

- feat(elements): support table template class param (95021f1)
- feat(elements): add table class param usage (602b8a0)
- fix(o-fixed-header-table): better align examples (09557ec)
- fix(o-fixed-header-table): terse bold wrap notice (634b2ed)
- chore(o-fixed-header-table): don't abuse `<dd>`'s (9a36f9e)

## Testing

1. Open "O Fixed Table Header".
2. Verify two tables appear.
3. Verify both tables scroll.
4. Verify header on each table stays in view when scrolling.
5. Verify notes clarify that wrapper is not necessary, but just an in-case-you-need it option.

## UI

| scroll to top | scroll to bottom |
| - | - |
| ![scroll to top](https://user-images.githubusercontent.com/62723358/206020240-191db22c-b27d-4214-802d-1d58c1a5fe6e.png) | ![scroll to bottom](https://user-images.githubusercontent.com/62723358/206020247-a1aa48d1-1f5c-4cef-85e5-b58444be5cc7.png) |
