### PR TITLE
feat(cortal.icons): collapse alias

### DIFF
--- a/src/lib/_imports/components/cortal.icon.css
+++ b/src/lib/_imports/components/cortal.icon.css
@@ -86,3 +86,8 @@ Styleguide Components.Cortal.Icon
 .icon-nav-right {
   transform: rotate(-45deg) translate(-1px, -1px);
 }
+
+/* To create alias for permissable icon name mistake */
+.icon-collapse::before {
+  content: "\ea15"; /* from `.icon-contract::before` */
+}


### PR DESCRIPTION
## Overview & Changes

Add `collapse` alias, because devs keep thinking it exists, even though it is created as `contract`.

## Related

- inspired by https://github.com/TACC/tup-ui/pull/76

## Testing / UI

Skipped. This change has proven reliable multiple times in the past. I am sorry I do not have time to hunt down instances.