### PR TITLE
feat: use css "project" layer for client context styles

### DIFF
--- a/fractal.config.js
+++ b/fractal.config.js
@@ -66,17 +66,17 @@ fractal.components.set('default.context', {
   }],
   cmsStyles: [{
     isInternal: true,
-    layer: 'base',
+    layer: 'project',
     path: '/assets/core-styles.cms.css'
   }],
   docsStyles: [{
     isInternal: true,
-    layer: 'base',
+    layer: 'project',
     path: '/assets/core-styles.docs.css'
   }],
   portalStyles: [{
     isInternal: true,
-    layer: 'base',
+    layer: 'project',
     path: '/assets/core-styles.portal.css'
   }]
 });

--- a/src/lib/_imports/_partials/import-client-styles.hbs
+++ b/src/lib/_imports/_partials/import-client-styles.hbs
@@ -1,0 +1,17 @@
+<style>
+{{#each styles}}
+  {{#if this.isInternal}}
+    {{#if this.layer}}
+    @import url('{{path this.path}}') layer({{this.layer}});
+    {{else}}
+    @import url('{{path this.path}}');
+    {{/if}}
+  {{else}}
+    {{#if this.layer}}
+    @import url('{{this.path}}') layer({{this.layer}});
+    {{else}}
+    @import url('{{this.path}}');
+    {{/if}}
+  {{/if}}
+{{/each}}
+</style>

--- a/src/lib/_imports/_preview.hbs
+++ b/src/lib/_imports/_preview.hbs
@@ -20,42 +20,19 @@
 {{/if}}
 
 <!-- Styles: Global (for every pattern) -->
-<style>
-{{#each globalStyles}}
-  {{#if this.isInternal}}
-  @import url('{{path this.path}}');
-  {{else}}
-  @import url('{{this.path}}');
-  {{/if}}
-{{/each}}
-</style>
+{{> @import-client-styles styles=globalStyles }}
 
 {{#if _target.context.shouldLoadCMS }}
 {{#unless _target.context.shouldSkipCMS }}
 <!-- Styles: Global (for current pattern): CMS -->
-<style>
-{{#each cmsStyles}}
-  {{#if this.isInternal}}
-  @import url('{{path this.path}}');
-  {{else}}
-  @import url('{{this.path}}');
-  {{/if}}
-{{/each}}
-</style>
+{{> @import-client-styles styles=cmsStyles }}
 {{/unless}}
 {{/if}}
 
 {{#if _target.context.shouldLoadDocs }}
 {{#unless _target.context.shouldSkipDocs }}
 <!-- Styles: Global (for current pattern): Docs -->
-<style>
-{{#each docsStyles}}
-  {{#if this.isInternal}}
-  @import url('{{path this.path}}');
-  {{else}}
-  @import url('{{this.path}}');
-  {{/if}}
-{{/each}}
+{{> @import-client-styles styles=docsStyles }}
 </style>
 {{/unless}}
 {{/if}}
@@ -63,15 +40,7 @@
 {{#if _target.context.shouldLoadPortal }}
 {{#unless _target.context.shouldSkipPortal }}
 <!-- Styles: Global (for current pattern): Portal -->
-<style>
-{{#each portalStyles}}
-  {{#if this.isInternal}}
-  @import url('{{path this.path}}');
-  {{else}}
-  @import url('{{this.path}}');
-  {{/if}}
-{{/each}}
-</style>
+{{> @import-client-styles styles=portalStyles }}
 {{/unless}}
 {{/if}}
 


### PR DESCRIPTION
## Overview

Load CMS, Portal, and Docs client context styles in CSS `project` layer.

<details><summary>Why do you do this major change right now?</summary>

So Docs client styles take precedence over Base styles like https://github.com/TACC/TACC-Docs styles expects. That client's `core-styles.docs-candidate.css` is being migrated in this PR (which does not work without this infrastructure update):
- #159

</details>

## Related

- mimics how theseclients load CSS:
    - https://github.com/TACC/TACC-Docs
    - [TACC/Core-CMS](https://github.com/TACC/Core-CMS/pull/581)
    - https://github.com/TACC/tup-ui
- required by  #159

## Changes

- **changed** layer in which to load client styles
- **added** logic to use previously ignored layer for client styles
- **added** partial `import-client-styles.hbs` for redundant logic
- **changed** preview template to use `import-client-styles.hbs`

## Testing

1. Load client-specific patterns.
2. Verify styles are unchanged.

## UI

### C-Message, Type & Scope

| | cms | portal
| - | - | -
| type | ![components message type cms](https://user-images.githubusercontent.com/62723358/236092903-22b81755-aae7-4df1-92fb-5767d7e213ca.png) | ![components message type portal](https://user-images.githubusercontent.com/62723358/236092914-d13949e1-c19d-402d-a508-2e55eed86ad5.png)
| scope | ![components message scope cms](https://user-images.githubusercontent.com/62723358/236092918-ad14e86e-9860-427f-a80e-fc9684992fa6.png) | ![components message scope portal](https://user-images.githubusercontent.com/62723358/236092922-8c547827-00b6-4aea-b782-86102333deb9.png)

### Monospace & @import layer syntax

| | cms | portal
| - | - | -
| render | ![elements monopsace cms](https://user-images.githubusercontent.com/62723358/236093281-46385743-ba16-4eb9-983a-adce76a0b407.png) | ![elements monopsace docs](https://user-images.githubusercontent.com/62723358/236093290-48bc3728-d1a0-48c5-8d08-b3c02d89ca54.png)
| @import | ![elements monopsace cms layer](https://user-images.githubusercontent.com/62723358/236093295-4cfad21c-8cca-4340-b9db-ecb3ae9414c5.png) | ![elements monospace docs layer](https://user-images.githubusercontent.com/62723358/236093301-c32a8a94-c9db-4952-9bea-38121ba517e0.png)

### Root Element

| cms | portal | docs
| - | - | -
| ![elements root cms](https://user-images.githubusercontent.com/62723358/236093860-12051362-42c9-45a8-adfb-0947f36d7835.png) | ![elements root docs](https://user-images.githubusercontent.com/62723358/236093876-a78875f9-c9be-41ff-bde5-436e09501bcb.png) | ![elements root portal](https://user-images.githubusercontent.com/62723358/236093868-767b819a-2841-460a-a2ba-8e27eb3057c4.png)

### HTML Elements

| cms | portal | docs
| - | - | -
| ![elements html cms](https://user-images.githubusercontent.com/62723358/236094518-d84b173b-4fad-4243-b78a-2b2778bab2d1.png) | ![elements html docs](https://user-images.githubusercontent.com/62723358/236094519-85602d52-d888-46c9-b9d1-9356539c2207.png) | ![elements html portal](https://user-images.githubusercontent.com/62723358/236094521-0b49966b-3911-42cf-862a-72ed59547d4c.png)

### Font

| base | cms | portal
| - | - | -
| ![settings font base](https://user-images.githubusercontent.com/62723358/236094692-10438959-87e5-47cf-8734-6775b73676c6.png) | ![settings font cms](https://user-images.githubusercontent.com/62723358/236094697-aefc0b7e-65d6-4d79-9e7c-42c526bb8a19.png) | ![settings font docs](https://user-images.githubusercontent.com/62723358/236094698-9ad7577b-35d4-45ba-b921-b4ee8a6e4d1b.png)

### Form

| base | cms | portal
| - | - | -
| ![components form base](https://user-images.githubusercontent.com/62723358/236094424-60a8efc5-3558-4008-bac2-155958c1f168.png) | ![components form cms](https://user-images.githubusercontent.com/62723358/236094425-027e2d7f-692c-42d6-8875-2819ea040845.png) | ![components form portal](https://user-images.githubusercontent.com/62723358/236094426-bb470739-b881-4dd7-9933-fdf58307e209.png)
