### PR TITLE
feat(partials): add img-url, have img use it

### DIFF
--- a/src/lib/_imports/_partials/img-url.hbs
+++ b/src/lib/_imports/_partials/img-url.hbs
@@ -1,0 +1,31 @@
+{{#if large}}
+
+  {{#if wide}}
+https://cep.tacc.utexas.edu/media/filer_public/db/ff/dbff8f57-5b25-4273-8e6f-ae95462e7d19/spectrum-wide-1024px.png
+  {{else if tall}}
+https://cep.tacc.utexas.edu/media/filer_public/87/b2/87b24b37-7b66-4d4a-b305-47c2308892ea/spectrum-tall-1024px.png
+  {{else}}
+https://cep.tacc.utexas.edu/media/filer_public/5b/3b/5b3bbbf6-eb43-4853-b19e-9b7c67944648/spectrum-square-1024px.png
+  {{/if}}
+
+{{else if medium}}
+
+  {{#if wide}}
+https://cep.tacc.utexas.edu/media/filer_public/14/15/1415253c-940f-452d-968e-0a17bd158867/spectrum-wide-600px.png
+  {{else if tall}}
+https://cep.tacc.utexas.edu/media/filer_public/7d/85/7d85cf91-6638-4e95-9c81-f65a1355abd3/spectrum-tall-600px.png
+  {{else}}
+https://cep.tacc.utexas.edu/media/filer_public/b3/22/b3228470-1a75-4142-a21e-f358b4190505/spectrum-square-600px.png
+  {{/if}}
+
+{{else}}
+
+  {{#if wide}}
+https://cep.tacc.utexas.edu/media/filer_public/fb/3f/fb3fd4c3-6360-4759-b607-f393b84558c0/spectrum-wide-320px.png
+  {{else if tall}}
+https://cep.tacc.utexas.edu/media/filer_public/c9/eb/c9ebd744-14d3-43ed-bc2e-86ed96eeef8a/spectrum-tall-320px.png
+  {{else}}
+https://cep.tacc.utexas.edu/media/filer_public/69/85/698569d0-641f-4289-94c2-664389d626e8/spectrum-square-240px.png
+  {{/if}}
+
+{{/if}}

--- a/src/lib/_imports/_partials/img.hbs
+++ b/src/lib/_imports/_partials/img.hbs
@@ -1,35 +1,5 @@
 <img
   {{#if class}}class="{{ class }}"{{/if}}
-  {{#if large}}
-
-    {{#if wide}}
-  src="https://cep.tacc.utexas.edu/media/filer_public/db/ff/dbff8f57-5b25-4273-8e6f-ae95462e7d19/spectrum-wide-1024px.png"
-    {{else if tall}}
-  src="https://cep.tacc.utexas.edu/media/filer_public/87/b2/87b24b37-7b66-4d4a-b305-47c2308892ea/spectrum-tall-1024px.png"
-    {{else}}
-  src="https://cep.tacc.utexas.edu/media/filer_public/5b/3b/5b3bbbf6-eb43-4853-b19e-9b7c67944648/spectrum-square-1024px.png"
-    {{/if}}
-
-  {{else if medium}}
-
-    {{#if wide}}
-  src="https://cep.tacc.utexas.edu/media/filer_public/14/15/1415253c-940f-452d-968e-0a17bd158867/spectrum-wide-600px.png"
-    {{else if tall}}
-  src="https://cep.tacc.utexas.edu/media/filer_public/7d/85/7d85cf91-6638-4e95-9c81-f65a1355abd3/spectrum-tall-600px.png"
-    {{else}}
-  src="https://cep.tacc.utexas.edu/media/filer_public/b3/22/b3228470-1a75-4142-a21e-f358b4190505/spectrum-square-600px.png"
-    {{/if}}
-
-  {{else}}
-
-    {{#if wide}}
-  src="https://cep.tacc.utexas.edu/media/filer_public/fb/3f/fb3fd4c3-6360-4759-b607-f393b84558c0/spectrum-wide-320px.png"
-    {{else if tall}}
-  src="https://cep.tacc.utexas.edu/media/filer_public/c9/eb/c9ebd744-14d3-43ed-bc2e-86ed96eeef8a/spectrum-tall-320px.png"
-    {{else}}
-  src="https://cep.tacc.utexas.edu/media/filer_public/69/85/698569d0-641f-4289-94c2-664389d626e8/spectrum-square-240px.png"
-    {{/if}}
-
-  {{/if}}
+  src="{{> @img-url wide=wide tall=tall large=large medium=medium }}"
   alt="(sample image)"
 />


### PR DESCRIPTION
## Overview / Changes

Add an `img-url` partial (and update `img` partial to use it).

<sup>This lets sample markup authors pick just image URLs (like for `<a>` to use).</sup>

## Related

- required by #169
- builds upon #170

## Testing

1. Load "Components" > "Align".
2. Verify images load.
1. Load "Elements" > "HTML Elements".
2. Verify images load.

## UI

| Components | Elements |
| - | - |
| ![components align](https://github.com/TACC/Core-Styles/assets/62723358/a8e95b19-0dbd-4dfc-95d3-e3cf85a1b451) | ![elements html](https://github.com/TACC/Core-Styles/assets/62723358/78427592-6df9-4c3c-8edd-fdf39c554aa8) |

