### PR TITLE
docs: isolate & update contrib. docs like core-cms

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,49 +247,7 @@ _Later_, the demo may be deployed indpendently and `core-styles.….css` served 
 
 ## Contributing
 
-### Development Workflow
-
-We use a modifed version of [GitFlow](https://datasift.github.io/gitflow/IntroducingGitFlow.html) as our development workflow. Our [development site](https://dev.cep.tacc.utexas.edu) (accessible behind the TACC Network) is always up-to-date with `main`, while the [production site](https://prod.cep.tacc.utexas.edu) is built to a hashed commit tag.
-
-- Feature branches contain major updates, bug fixes, and hot fixes with respective branch prefixes:
-  - `task/` for features and updates
-  - `bug/` for bugfixes
-  - `fix/` for hotfixes
-
-### Best Practices
-
-Sign your commits ([see this link](https://help.github.com/en/github/authenticating-to-github/managing-commit-signature-verification) for help).
-
-### Publishing Workflow
-
-Only authorized team members may publish.
-
-1. (one time) Login to npm via:\
-    `npm login`
-1. Create new branch for version bump.
-1. Update `CHANGELOG.md`.
-1. Update version via:\
-    `npm version N.N.N`
-1. Commit, push, open pull request, get approval.\
-    <sup>Do **not** merge yet.</sup>
-1. Publish to NPM via `npm publish --access public`.\
-    <sup>Project build will automatically occur before publish.[^1]</sup>
-1. Commit NPM build output.
-1. Merge pull request.
-1. Create release and tag on GitHub.
-1. Replace Github's unannotated tag with an annotated one:
-    - `git pull`
-    - `git tag -d vN.N.N`
-    - `git tag -a vN.N.N -m "____: vN.N.N"`
-    - `git push --tags --force`
-
-[^1]: **Help**: How to set build ID arg on build command during publish auto-build?
-
-### Resources
-
-- [Learn Markdown](https://bitbucket.org/tutorials/markdowndemo)
-- [Research & Development](https://confluence.tacc.utexas.edu/x/FADMBQ)
-
+To contribute, first read [How to Contirbute][Contributing].
 
 <!-- Link Aliases -->
 
@@ -299,3 +257,5 @@ Only authorized team members may publish.
 [core portal]: https://github.com/TACC/Core-Portal
 [tup ui]: https://github.com/TACC/tup-ui
 [tacc docs]: https://github.com/TACC/TACC-Docs
+
+[Contributing]: ./docs/contributing.md

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,54 @@
+
+## Linting and Formatting
+
+Not standardized. Read [(internal) Formatting & Linting](https://confluence.tacc.utexas.edu/x/HoBGCw).
+
+## Best Practices
+
+- [Sign your commits.](https://help.github.com/en/github/authenticating-to-github/managing-commit-signature-verification)
+- [Learn Markdown.](https://bitbucket.org/tutorials/markdowndemo)
+
+## Development Workflow
+
+We use a modifed version of [GitFlow](https://datasift.github.io/gitflow/IntroducingGitFlow.html).
+
+- "feature branches" have a specific prefix:
+  - `feat/` for features and updates
+  - `fix/` for bugfixes and hotfixes
+  - `refactor/` for large internal changes
+  - `style/` for code style changes (white-space, formatting, etc.)
+  - `chore/` for no-op changes
+  - `docs/` for documentation
+  - `perf/` for performance improvements
+  - `test/` for test case updates
+  - or other "types" from [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
+- "develop" branch is usually `main`,\
+    <sup>but can exist as a long-lived multi-feature branch prefixed with `dev/`</sup>
+- "release branches" (as needed) are prefixed with `release/`
+- "hotfix branches" are prefixed `fix/`
+- "master branch" is always `main`
+
+## Release Workflow
+
+Only appointed team members may release versions.
+
+1. (one time) Login to npm via:\
+    `npm login`
+1. Create new branch for version bump.
+1. Update `CHANGELOG.md`.
+1. Update version via:\
+   `npm version N.N.N`
+1. Commit, push, PR, review.\
+    <sup>Do **not** merge yet.</sup>
+1. Publish to NPM via `npm publish --access public`.\
+    <sup>Project build will automatically occur before publish.[^1]</sup>
+1. Commit NPM build output.
+1. Merge pull request.
+1. Create release and tag on GitHub.
+1. Replace Github's unannotated tag with an annotated one:
+   - `git pull`
+   - `git checkout vN.N.N`
+   - `git tag -d vN.N.N`
+   - `git tag -a vN.N.N -m "____: vN.N.N"`
+   - `git push --tags --force`
+


### PR DESCRIPTION
## Overview

Isolate and update "How to Contibute" instructions to match [Core-CMS](https://github.com/TACC/Core-CMS) more closely.

## Related

- mimics some of https://github.com/TACC/Core-CMS/pull/665

## Changes

- **moves** contributing documentation to its own doc

## Testing & UI

View "rich diffs" of the markdown files in the PR diff.