### PR TITLE
feat: handlebars helpers "eq" and "has"

### DIFF
--- a/fractal.config.js
+++ b/fractal.config.js
@@ -90,5 +90,14 @@ fractal.web.set('builder.dest', __dirname + '/demo');
 // Customize theme
 fractal.web.theme(theme);
 
+// Add template helpers
+const engine = fractal.components.engine();
+engine.handlebars.registerHelper('eq', function(a, b) {
+  return a == b;
+});
+engine.handlebars.registerHelper('has', function(array, item) {
+  return array.includes(item);
+});
+
 // Export
 module.exports = fractal;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@frctl/fractal": "^1.5.13",
+        "@frctl/handlebars": "^1.2.15",
         "@frctl/mandelbrot": "^1.10.1",
         "minimist": "^1.2.7",
         "npm-watch": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "@frctl/fractal": "^1.5.13",
+    "@frctl/handlebars": "^1.2.15",
     "@frctl/mandelbrot": "^1.10.1",
     "minimist": "^1.2.7",
     "npm-watch": "^0.11.0"


### PR DESCRIPTION
## Overview

Customize Handlebars by adding two helpers, `eq` and `has`.

## Related

- required by #195

## Changes

- **added** handlebars dependency
- **added** handlebars helper `eq` (a **eq**uals b)
- **added** handlebars helper `has` (array **has** item)

## Testing

```
{{#if (has some_array "some string in that array")}}
Array has the string.
{{/if}}
```

```
{{#if (eq some_string "equal string")}}
Strings are equal.
{{/if}}
```

Tested via #195.