### PR TITLE
fix: demo/support boxed and piped c-nav

### DIFF
--- a/src/lib/_imports/components/c-nav/config.yml
+++ b/src/lib/_imports/components/c-nav/config.yml
@@ -13,8 +13,11 @@ variants:
     context:
       modifiers:
         - [piped]
+        - [piped, boxed]
         - [piped, piped--before]
+        - [piped, boxed, piped--before]
         - [piped, piped--after]
+        - [piped, boxed, piped--after]
     status: wip
   - name: no-list
     context:


### PR DESCRIPTION
## Overview

Support nav component that is both "piped" and "boxed".

## Related

- adds to #195

## Changes

- **added** demo of `boxed` + `piped` nav component

## Testing

1. Verify piped nav component fits in a box with no extra space.

## UI

<img width="1150" alt="Screenshot 2023-07-20 at 10 57 52 AM" src="https://github.com/TACC/Core-Styles/assets/62723358/d64f3e75-318c-448d-871c-56cdb1622cfb">