### PR TITLE
fix: checkbox label should not have margin bottom

### DIFF
--- a/src/lib/_imports/elements/form.cms.css
+++ b/src/lib/_imports/elements/form.cms.css
@@ -17,7 +17,6 @@ label {
   font-weight: var(--medium);
 
   line-height: normal;
-  margin-bottom: 0.75em;
 }
 /* To avoid extra space between field wrappers */
 /* FAQ: The known use case is a django.cms.forms `.checkboxselectmultiple` */
@@ -28,6 +27,7 @@ li > label:only-child {
 /* FAQ: Any specific form styling (e.g. django.cms.forms) manages this */
 :not(input[type="checkbox"]) + label {
   display: block;
+  margin-bottom: 0.75em;
 }
 
 


### PR DESCRIPTION
## Overview

Do not add margin-bottom under checkbox labels.

## Related

None.

## Changes

- moved margin-bottom  for labels to only non-checkbox labels

## Testing

1. Visit http://localhost:3000/components/detail/c-form--cms.
1. Check that label for a checkbox does **not** have margin-bottom.

## UI

| before | after |
| - | - |
| ![before](https://github.com/TACC/Core-Styles/assets/62723358/886f085a-30db-4764-8156-71a0443d6a56) | ![after](https://github.com/TACC/Core-Styles/assets/62723358/443748d7-6072-4c0f-8f3b-c2ea432f1c8f) |