### PR TITLE
fix: cms table & s-paragraph-table demo (demo cmsStyles now in base layer)

### DIFF
--- a/fractal.config.js
+++ b/fractal.config.js
@@ -66,7 +66,7 @@ fractal.components.set('default.context', {
   }],
   cmsStyles: [{
     isInternal: true,
-    layer: 'project',
+    layer: 'base',
     path: '/assets/core-styles.cms.css'
   }],
   docsStyles: [{

--- a/src/lib/_imports/trumps/s-paragraph-table/config.yml
+++ b/src/lib/_imports/trumps/s-paragraph-table/config.yml
@@ -1,4 +1,7 @@
+label: "S Paragraph Table (CMS)"
 context:
+  shouldLoadCMS: true
+  ⚠️ shouldLoadCMS: only works well in CMS, because its code is in table.cms.css
   data:
     rows:
       - paragraph: true


### PR DESCRIPTION
## Overview & Changes

- Load CMS styles in base layer (like TUP does).
- Highlight that `s-paragraph-table` is only for CMS.

## Related

- fixes demos that I saw were broken (I feared a bug that would propagate to clients)

## Testing

1. Open [table--via-paragraphs-cms](http://localhost:3000/components/detail/table--via-paragraphs-cms) and [s-paragraph-table](http://localhost:3000/components/detail/s-paragraph-table).
2. Verify:
    - top border is thicker than normal table
    - bottom border is present (and thick)
    - cells' vertical padding is larger than regular table
    - cells (i.e. paragraphs) do **not** have margin

## UI

| | Before | After |
| - | - | - |
| table--via-paragraphs-cms | <img width="992" alt="cms before" src="https://github.com/TACC/Core-Styles/assets/62723358/9a943ec2-59de-4607-973b-13fd198a1316"> | <img width="992" alt="cms after" src="https://github.com/TACC/Core-Styles/assets/62723358/6943b6cf-4a4d-486a-b6c5-1dfe92263a74"> |
| s-paragraph-table | <img width="992" alt="spt before" src="https://github.com/TACC/Core-Styles/assets/62723358/8f31fceb-a01c-451a-96a9-c052fbd58216"> | <img width="992" alt="spt after" src="https://github.com/TACC/Core-Styles/assets/62723358/e4c28e86-7281-42b6-b036-14b43f6d6b08"> |

## Notes

0. Client layer should mirror Demo.
1. Client layers were fixed (in TUP).
3. But Demo layers were NOT fixed.
4. Now, Demo layers are fixed.