### PR TITLE
fix: open ext. links in new window code not dry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ node_modules
 
 # Fractal
 demo
+## Files used directly by demo but not clients, yet provided via dist
+dist/_utils
 ## Empty file touched after auto-rebuild to trigger server live-refresh */
 fractal.server.refresh.css
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "build": "npm run build:css && npm run build:demo",
     "build:css": "bin/build.js --build-id=$npm_config_build_id",
     "postbuild:css": "rm -rf dist/fonts && cp -r src/lib/fonts dist/fonts",
+    "prebuild:demo": "rm -rf dist/_utils && cp -r src/lib/_utils dist/_utils",
+    "prestart": "npm run prebuild:demo",
     "build:demo": "fractal build",
     "test": "bin/test.js && echo \"Test output at 'dist/_tests' (compare to test input)\"",
     "build:watch": "npm run build:css && touch src/lib/_imports/fractal.server.refresh.css",

--- a/src/lib/_imports/components/admonition/readme.md
+++ b/src/lib/_imports/components/admonition/readme.md
@@ -6,9 +6,4 @@ To style ["Admonition" messages][rtd-admonition].
 
 [rtd-admonition]: https://learning-readthedocs.readthedocs.io/en/latest/Options/admonition.html "ReadTheDocs: Admonition"
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_utils/js/open-ext-links-in-new-window.js
+++ b/src/lib/_utils/js/open-ext-links-in-new-window.js
@@ -1,0 +1,4 @@
+/* To open external links in new window */
+Array.from(document.links)
+  .filter(link => link.hostname != window.location.hostname)
+  .forEach(link => link.target = '_blank');


### PR DESCRIPTION
## Overview

Reduce duplication of code when component readme has links that should open in new window.

## Related

None. This has just been too annoying.

## Changes

- **added** `.gitignore` rule for demo scripts
- **added** javascript do the job
- **added** auto-run scripts to copy javascript
- **changed** one readme to use new script

## Testing

1. Open http://localhost:3000/components/detail/admonition.
2. View the "Notes".
3. Click the external link, [“Admonition” messages](https://learning-readthedocs.readthedocs.io/en/latest/Options/admonition.html).
4. Verify link opens in new window.

## UI

https://github.com/TACC/Core-Styles/assets/62723358/db5c1fc1-261e-478f-b135-c609989f0672