### PR TITLE
chore: open all ext. links in readme via new tab

### DIFF
--- a/src/lib/_imports/components/align/readme.md
+++ b/src/lib/_imports/components/align/readme.md
@@ -23,9 +23,4 @@ Simple classes to align media or content within paragraphs:
 [source]: https://github.com/django-cms/djangocms-picture/blob/2.3.0/djangocms_picture/models.py#L24-L34
 [TACC-Docs]: https://github.com/TACC/TACC-Docs/
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/components/bootstrap/bootstrap--container.readme.md
+++ b/src/lib/_imports/components/bootstrap/bootstrap--container.readme.md
@@ -46,9 +46,4 @@ To add wider [Bootstrap Grid](https://getbootstrap.com/docs/4.0/layout/grid/) co
   </tbody>
 </table>
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/components/bootstrap/bootstrap--form.readme.md
+++ b/src/lib/_imports/components/bootstrap/bootstrap--form.readme.md
@@ -9,9 +9,4 @@ To override and extend [Bootstrap Forms](https://getbootstrap.com/docs/4.3/compo
 > - [ ] **Either** migrate Portal Bootstrap form styling to this component.
 > - [ ] **Or** return these styles to Portal (and remove form Core Styles).
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/components/bootstrap/bootstrap--modal.readme.md
+++ b/src/lib/_imports/components/bootstrap/bootstrap--modal.readme.md
@@ -4,9 +4,4 @@ To override and extend [Bootstrap Modals](https://getbootstrap.com/docs/4.3/comp
 >
 > The modal will not scroll unless using [Bootstrap 4.3](https://getbootstrap.com/docs/4.3/components/modal/). CMS uses [Bootstrap 4.0](https://getbootstrap.com/docs/4.0/components/modal/). The relevant class is `modal-dialog-scrollable`.
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/components/bootstrap/bootstrap--nav-tabs.readme.md
+++ b/src/lib/_imports/components/bootstrap/bootstrap--nav-tabs.readme.md
@@ -1,8 +1,3 @@
 To override and extend [Bootstrap Nav Tabs](https://getbootstrap.com/docs/4.3/components/navs/#tabs).
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/components/bootstrap/bootstrap.readme.md
+++ b/src/lib/_imports/components/bootstrap/bootstrap.readme.md
@@ -6,9 +6,4 @@
 >
 > Overwriting Bootstrap is cumbersome and **not** the [appropriate way to theme Bootstrap](https://getbootstrap.com/docs/4.0/getting-started/theming/), but TACC Core is **not** using SASS; it uses PostCSS.
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/components/c-data-list/description-list/readme.md
+++ b/src/lib/_imports/components/c-data-list/description-list/readme.md
@@ -1,8 +1,3 @@
 Use [a Description List](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl).
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/components/c-data-list/readme.md
+++ b/src/lib/_imports/components/c-data-list/readme.md
@@ -1,8 +1,3 @@
 Suitable markup is [Table elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element#table_content) and [Description Lists](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl).
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/components/c-data-list/table/readme.md
+++ b/src/lib/_imports/components/c-data-list/table/readme.md
@@ -4,9 +4,4 @@ Use [Table elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element#t
 >
 > Narrow the viewport to see truncation of values.
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/components/c-form/readme.md
+++ b/src/lib/_imports/components/c-form/readme.md
@@ -1,8 +1,3 @@
 To style when raw [Form elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element#table_content) alone are **not** sufficient.
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/components/c-island/readme.md
+++ b/src/lib/_imports/components/c-island/readme.md
@@ -4,9 +4,4 @@ A portion of a document whose content is only indirectly related to the document
 >
 > The [`<aside>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside) is usually the appropriate element for this pattern.
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/components/c-pill/readme.md
+++ b/src/lib/_imports/components/c-pill/readme.md
@@ -10,9 +10,4 @@ To label the status of something.
 
 <small>* Requires client styles, because [truncation can be context-dependent](https://confluence.tacc.utexas.edu/x/sAoFDg).</small>
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/components/django-cms-forms/readme.md
+++ b/src/lib/_imports/components/django-cms-forms/readme.md
@@ -12,9 +12,4 @@ To style forms built by [Django CMS forms][djcms-forms].
 [djcms-forms-tpl]: https://github.com/avryhof/djangocms-forms/blob/ab38b22/djangocms_forms/templates/djangocms_forms/form_template/default.html "DjangoCMS Forms (Maintained) Template"
 [django-form-widgets]: https://docs.djangoproject.com/en/2.2/ref/forms/widgets/ "Django Form Widgets"
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/components/pymdownx/pymdownx.readme.md
+++ b/src/lib/_imports/components/pymdownx/pymdownx.readme.md
@@ -1,8 +1,3 @@
 Styles for markup with classes from [PyMdown Extensions](https://facelessuser.github.io/pymdown-extensions/).
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/components/tacc-docs/readme.md
+++ b/src/lib/_imports/components/tacc-docs/readme.md
@@ -15,9 +15,4 @@ Components used on [TACC-Docs].
 [TACC-Docs]: https://github.com/TACC/TACC-Docs/
 [Node]: https://nodejs.org/en/
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/elements/form.cms/readme.md
+++ b/src/lib/_imports/elements/form.cms/readme.md
@@ -8,9 +8,4 @@
 >
 > These overwrite, but may accidentally rely on, [Bootstrap Reboot: Forms](https://getbootstrap.com/docs/4.0/content/reboot/#forms).
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/elements/headings/readme.md
+++ b/src/lib/_imports/elements/headings/readme.md
@@ -4,9 +4,4 @@
 <h1> <h2> <h3> <h4> <h5> <h6>
 ```
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/elements/links/readme.md
+++ b/src/lib/_imports/elements/links/readme.md
@@ -1,8 +1,3 @@
 The [`<a>` anchor element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a).
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/elements/root/readme.md
+++ b/src/lib/_imports/elements/root/readme.md
@@ -1,8 +1,3 @@
 The [`<html>` element (Main root)](https://developer.mozilla.org/en-US/docs/Web/HTML/Element#Main_root) and [`<body>` element (Sectioning root)](https://developer.mozilla.org/en-US/docs/Web/HTML/Element#Sectioning_root).
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/elements/table/readme.md
+++ b/src/lib/_imports/elements/table/readme.md
@@ -4,9 +4,4 @@
 <table> <thead> <tbody> <th> <td> <tfoot> <colgroup> <col> <caption>
 ```
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/elements/table/table--via-paragraphs.readme.md
+++ b/src/lib/_imports/elements/table/table--via-paragraphs.readme.md
@@ -5,9 +5,4 @@ A [table]({{path './table' }}) that uses [paragraphs](https://developer.mozilla.
 > - Text will not truncate. It will wrap.
 > - Only a single column is supported.
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/elements/table/table--with-paragraphs.readme.md
+++ b/src/lib/_imports/elements/table/table--with-paragraphs.readme.md
@@ -4,9 +4,4 @@ A [table]({{path './table' }}) with cells that have [paragraphs](https://develop
 >
 > On [Portal tables]({{path './table--with-paragraphs-portal' }}) and [`s-truncated-table`s]({{path './s-data-table' }}), text in a `<p>` tag. will truncate at N lines; see [truncate mixin]({{path './x-truncate' }}) to control line count.
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/objects/o-fixed-header-table/readme.md
+++ b/src/lib/_imports/objects/o-fixed-header-table/readme.md
@@ -14,9 +14,4 @@ A [table]({{path './table' }}) with its header pinned during vertical scroll.
 
 [source]: https://css-tricks.com/position-sticky-and-table-headers/ "CSS Tricks: Position Sticky & Table Headers"
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/objects/o-flex-item-table-wrap/readme.md
+++ b/src/lib/_imports/objects/o-flex-item-table-wrap/readme.md
@@ -14,9 +14,4 @@ Make [table]({{path './table' }}) behave like a flex item, for a specific CEPv2 
 
 [source]: https://stackoverflow.com/a/41421700/11817077 "Stack Overflow: Why does flex-box work with a div, but not a table?"
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/objects/o-section/readme.md
+++ b/src/lib/_imports/objects/o-section/readme.md
@@ -24,9 +24,4 @@ Older features are not illustrated in the demo:
 | `.o-section--layout-c`    | (on wider screens) 1 narrow column & 1 wide column
 | `.o-section--layout-d`    | (on wider screens) 3 even columns
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/objects/o-table-wrap/o-table-wrap--flexible-horz.readme.md
+++ b/src/lib/_imports/objects/o-table-wrap/o-table-wrap--flexible-horz.readme.md
@@ -12,9 +12,4 @@ For extra customization, see relevant <code>extra…</code> "File" from "Assets"
 
 [source-flex]: https://stackoverflow.com/a/41421700/11817077 "Stack Overflow: Why does flex-box work with a div, but not a table?"
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/objects/o-table-wrap/o-table-wrap--flexible-vert.readme.md
+++ b/src/lib/_imports/objects/o-table-wrap/o-table-wrap--flexible-vert.readme.md
@@ -10,9 +10,4 @@ Make [table]({{path './table' }}) width able to <strong>stretch</strong> <em>but
 
 [source-flex]: https://stackoverflow.com/a/41421700/11817077 "Stack Overflow: Why does flex-box work with a div, but not a table?"
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/objects/o-table-wrap/o-table-wrap--overflow-hidden.readme.md
+++ b/src/lib/_imports/objects/o-table-wrap/o-table-wrap--overflow-hidden.readme.md
@@ -6,9 +6,4 @@ For extra customization, see relevant <code>extra…</code> "File" from "Assets"
 >
 > This class can **only** be used on a table wrapper. It has **no** affect when used on table directly.
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/objects/o-table-wrap/o-table-wrap--overflow-scroll-extra.readme.md
+++ b/src/lib/_imports/objects/o-table-wrap/o-table-wrap--overflow-scroll-extra.readme.md
@@ -10,9 +10,4 @@ Make [table]({{path './table' }}) overflow <strong>scrollable</strong> (advanced
 
 [source-scroll]: https://stackoverflow.com/a/19794391/11817077 "Stack Overflow: Horizontal scroll on overflow of table (answer)"
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/objects/o-table-wrap/o-table-wrap--overflow-scroll.readme.md
+++ b/src/lib/_imports/objects/o-table-wrap/o-table-wrap--overflow-scroll.readme.md
@@ -12,9 +12,4 @@ For extra customization, see relevant <code>extra…</code> "File" from "Assets"
 
 [source-scroll]: https://stackoverflow.com/a/19794391/11817077 "Stack Overflow: Horizontal scroll on overflow of table (answer)"
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/objects/o-table-wrap/readme.md
+++ b/src/lib/_imports/objects/o-table-wrap/readme.md
@@ -16,9 +16,4 @@ For client customization examples, see relevant <code>example.…-….css</code>
 [source-flex]: https://stackoverflow.com/a/41421700/11817077 "Stack Overflow: Why does flex-box work with a div, but not a table?"
 [source-scroll]: https://stackoverflow.com/a/19794391/11817077 "Stack Overflow: Horizontal scroll on overflow of table (answer)"
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/settings/color/readme.md
+++ b/src/lib/_imports/settings/color/readme.md
@@ -1,8 +1,3 @@
 [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Variables) for colors.
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/settings/font/readme.md
+++ b/src/lib/_imports/settings/font/readme.md
@@ -1,8 +1,3 @@
 [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Variables) for [font](https://developer.mozilla.org/en-US/docs/Web/CSS/font) properties.
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/tools/x-link/readme.md
+++ b/src/lib/_imports/tools/x-link/readme.md
@@ -7,9 +7,4 @@ UI states of [`<a>` anchor element](https://developer.mozilla.org/en-US/docs/Web
 | `.x-link--hover`  | `:hover` state
 | `.x-link--active` | `:active` (click) state
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/tools/x-tabs/readme.md
+++ b/src/lib/_imports/tools/x-tabs/readme.md
@@ -14,9 +14,4 @@ Mixins for tab components e.g. [Bootstrap Nav Tabs]({{path './bootstrap--nav-tab
 | `.x-tabs__content--active`       | visible content
 | `.x-tabs__content--force-active` | to force content to be visible
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/trumps/s-affixed-input-wrapper/README.md
+++ b/src/lib/_imports/trumps/s-affixed-input-wrapper/README.md
@@ -16,9 +16,4 @@ _This is an isolated feature from [Bootstrap Input Group](https://getbootstrap.c
    - `<input type="date">` calendar
    - `<input type="time">` clock
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/trumps/s-blockquote/readme.md
+++ b/src/lib/_imports/trumps/s-blockquote/readme.md
@@ -4,9 +4,4 @@ A [`<blockquote>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blo
 >
 > Should this be implemented as `figure.has-blockquote` (fallback) `figure:has(blockquote)` (actual)? We can retain legacy support for `figure.s-blockquote` as an alternate class name.
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/trumps/s-form/readme.md
+++ b/src/lib/_imports/trumps/s-form/readme.md
@@ -1,8 +1,3 @@
 To style when mostly raw [Form elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element#table_content) are sufficient.
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/trumps/s-paragraph-table/readme.md
+++ b/src/lib/_imports/trumps/s-paragraph-table/readme.md
@@ -5,9 +5,4 @@ A [table]({{path './table' }}) that uses [paragraphs](https://developer.mozilla.
 > - Text will not truncate. It will wrap.
 > - Only a single column is supported.
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/trumps/s-truncated-table/readme.md
+++ b/src/lib/_imports/trumps/s-truncated-table/readme.md
@@ -4,9 +4,4 @@ A [table]({{path './table' }}) that uses a [table](https://developer.mozilla.org
 >
 > - Text will truncate only if it is in a `<p>` tag.
 
-<script>
-/* To open external links in new window */
-Array.from(document.links)
-  .filter(link => link.hostname != window.location.hostname)
-  .forEach(link => link.target = '_blank');
-</script>
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />


### PR DESCRIPTION
## Overview

Open all external links in a pattern "Notes" in a new window.

## Related

- requires #238

## Changes

- **changed** same script used in all pattern `readme.md`'s

## Testing & UI

Skipped.

## Notes

This is a courtesy PR. #238 already tested this. I just/find replace.