### PR TITLE
docs: allow small primary buttons

### DIFF
--- a/src/lib/_imports/components/c-button/c-button.hbs
+++ b/src/lib/_imports/components/c-button/c-button.hbs
@@ -8,14 +8,10 @@
         {{#if disabled}}disabled{{/if}}>
         <span class="c-button__text">--secondary</span>
       </button>
-      {{#if small}}
-        <small>(no small primary allowed)</small>
-      {{else}}
-        <button class="c-button c-button--{{this._self.name}} c-button--primary"
-        {{#if disabled}}disabled{{/if}}>
-          <span class="c-button__text">--primary</span>
-        </button>
-      {{/if}}
+      <button class="c-button c-button--{{this._self.name}} c-button--primary"
+      {{#if disabled}}disabled{{/if}}>
+        <span class="c-button__text">--primary</span>
+      </button>
       <button class="c-button c-button--{{this._self.name}} c-button--tertiary"
         {{#if disabled}}disabled{{/if}}>
         <span class="c-button__text">--tertiary</span>
@@ -29,14 +25,10 @@
         {{#if disabled}}disabled tabindex="-1"{{/if}}>
         <span class="c-button__text">--secondary</span>
       </a>
-      {{#if small}}
-        <small>(no small primary allowed)</small>
-      {{else}}
-        <a href="#" class="c-button c-button--{{this._self.name}} c-button--primary"
-        {{#if disabled}}disabled tabindex="-1"{{/if}}>
-          <span class="c-button__text">--primary</span>
-        </a>
-      {{/if}}
+      <a href="#" class="c-button c-button--{{this._self.name}} c-button--primary"
+      {{#if disabled}}disabled tabindex="-1"{{/if}}>
+        <span class="c-button__text">--primary</span>
+      </a>
       <a href="#" class="c-button c-button--{{this._self.name}} c-button--tertiary"
         {{#if disabled}}disabled tabindex="-1"{{/if}}>
         <span class="c-button__text">--tertiary</span>


### PR DESCRIPTION
## Overview

Advertise `c-button--size-small` and `c-button--type-primary` in one button.

<details>This always worked, but was just discouraged. Designer has changed his mind.</details>

## Related

- [TUP-599 designer direction (see "1.")](https://jira.tacc.utexas.edu/browse/TUP-599?focusedId=28380&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-28380)

## Changes

- **changed** `c-button.hbs`

## Testing

1. Load http://localhost:3002/components/detail/c-button--size-small.
2. Verify small primary buttons appear for `<button>` and `<a>`.

## UI

| before | after |
| - | - |
| ![before](https://github.com/TACC/Core-Styles/assets/62723358/c866a617-604a-4867-b117-238822ff8080) | ![after](https://github.com/TACC/Core-Styles/assets/62723358/3110f755-aeb9-43a6-88bf-bfa80037fb56) |