### PR TITLE
fix: missing c-pill styles on nested table

### DIFF
--- a/src/lib/_imports/elements/table/config.yml
+++ b/src/lib/_imports/elements/table/config.yml
@@ -325,15 +325,15 @@ variants:
               rows:
                 - name: Corral
                   custom-1: 50 GB
-                  custom-2: <span class="c-pill">13 GB</span>
+                  custom-2: <span class="c-pill c-pill--is-danger">13 GB</span>
                   time: 12/01/2019 11:04:19
                 - name: Hikari
                   custom-1: 21 SU
-                  custom-2: <span class="c-pill">1.5 SU</span>
+                  custom-2: <span class="c-pill c-pill--is-warning">1.5 SU</span>
                   time: 03/22/2021 05:23:01
                 - name: Ranch
                   custom-1: 1 TB
-                  custom-2: <span class="c-pill">932 GB</span>
+                  custom-2: <span class="c-pill c-pill--is-success">932 GB</span>
                   time: 12/01/2019 11:04:19
           - id: Vermillion
             name: Nathan Fillion
@@ -347,15 +347,15 @@ variants:
               rows:
                 - name: Corral
                   custom-1: 50 GB
-                  custom-2: <span class="c-pill">13 GB</span>
+                  custom-2: <span class="c-pill c-pill--is-danger">13 GB</span>
                   time: 12/01/2019 11:04:19
                 - name: Hikari
                   custom-1: 21 SU
-                  custom-2: <span class="c-pill">1.5 SU</span>
+                  custom-2: <span class="c-pill c-pill--is-warning">1.5 SU</span>
                   time: 03/22/2021 05:23:01
                 - name: Ranch
                   custom-1: 1 TB
-                  custom-2: <span class="c-pill">932 GB</span>
+                  custom-2: <span class="c-pill c-pill--is-success">932 GB</span>
                   time: 12/01/2019 11:04:19
           - id: Emerald
             name: Wesley Snipes
@@ -369,13 +369,13 @@ variants:
               rows:
                 - name: Corral
                   custom-1: 50 GB
-                  custom-2: <span class="c-pill">13 GB</span>
+                  custom-2: <span class="c-pill c-pill--is-danger">13 GB</span>
                   time: 12/01/2019 11:04:19
                 - name: Hikari
                   custom-1: 21 SU
-                  custom-2: <span class="c-pill">1.5 SU</span>
+                  custom-2: <span class="c-pill c-pill--is-warning">1.5 SU</span>
                   time: 03/22/2021 05:23:01
                 - name: Ranch
                   custom-1: 1 TB
-                  custom-2: <span class="c-pill">932 GB</span>
+                  custom-2: <span class="c-pill c-pill--is-success">932 GB</span>
                   time: 12/01/2019 11:04:19


### PR DESCRIPTION
## Overview

The nested table was lacking styled pills.

## Related

- noticed by designers while reviewing #275

## Changes

- **added** missing class names

## Testing

1. Open [/components/detail/table--nested](http://localhost:3000/components/detail/table--nested).
2. Verify nested tables have colored pills.

## UI

| before | after |
| - | - |
| <img width="1200" alt="before" src="https://github.com/TACC/Core-Styles/assets/62723358/1b3874ba-d595-436c-900a-c2aee5e930fe"> | <img width="1200" alt="after" src="https://github.com/TACC/Core-Styles/assets/62723358/e8031b83-177f-40d9-b438-97c727aa8dc9"> |