### PR TITLE
fix: load docs in base layer, like other clients

### DIFF
--- a/fractal.config.js
+++ b/fractal.config.js
@@ -71,7 +71,7 @@ fractal.components.set('default.context', {
   }],
   docsStyles: [{
     isInternal: true,
-    layer: 'project',
+    layer: 'base',
     path: '/assets/core-styles.docs.css'
   }],
   portalStyles: [{


### PR DESCRIPTION
## Overview

Fix CSS specificity bug by not loading docs stylesheet in project layer.

## Related

- fixes https://github.com/TACC/Core-Styles/pull/275#discussion_r1466512609

## Changes

- **changed** layer in which to import docs styles

## Testing

1. I tested this change on branch at https://github.com/TACC/Core-Styles/pull/275#discussion_r1466512609.
2. I skimmed all the Docs and "… (Docs)" patterns. They didn't look obviously wrong. 

## UI

Skipped. I accept all blame.

## Notes

I want to use layers. I think clients are the correct use case.

But… I keep needing to return client stylesheet imports to base layer to fix demo bugs.