### PR TITLE
hotfix: actually set hr color / fix typo

### DIFF
--- a/src/lib/_imports/elements/html-elements.cms.css
+++ b/src/lib/_imports/elements/html-elements.cms.css
@@ -103,7 +103,7 @@ Styleguide Elements.TextContent
 
   border-top-width: var(--global-border-width--normal);
   border-top-style: solid;
-  border-top-clolor: var(--global-color-primary--dark);
+  border-top-color: var(--global-color-primary--light);
 
   margin-bottom: var(--global-space--hr-buffer-below); /* overwrite Bootstrap */
 


### PR DESCRIPTION
## Overview

Fix typo. Set color to match what has been shown.

## Related

- near same code as #310

## Changes

- **fixed** CSS that was inactive

## Testing

### Demo

1. Test an `<hr>` on Core-Styles demo that uses CMS stylesheet e.g. http://localhost:3002/components/detail/headings--cms.
2. Verify HR color is set by core-styles and is similar to the color it has been.

### Client

1. Replicate changes in a client e.g. on https://tacc.utexas.edu/news/supplemental/2024/02/22/black-history-month-spotlight-cosby/?edit .
2. Verify HR color is set by core-styles and is similar to the color it has been.

## UI

### Demo (CMS Headings)

| Before | After |
| - | - |
| <img width="1194" alt="broken" src="https://github.com/TACC/Core-Styles/assets/62723358/52be88fa-e845-4c74-9667-e2f10c36069a"> | <img width="1194" alt="working" src="https://github.com/TACC/Core-Styles/assets/62723358/0cf279de-313e-4d6d-b7d0-79ee85c8ac2e"> |

### Client (TACC CMS)

| Before | After |
| - | - |
| <img width="1194" alt="before" src="https://github.com/TACC/Core-Styles/assets/62723358/43da447e-175b-42d6-9711-41857b61d2f2"> | <img width="1194" alt="after" src="https://github.com/TACC/Core-Styles/assets/62723358/29d9cc19-fbf0-4771-a856-ba30a3eca5cb"> | 