### PR TITLE
fix: CMD-79 navbar expanded can overflow header

### DIFF
--- a/src/lib/_imports/trumps/s-header.css
+++ b/src/lib/_imports/trumps/s-header.css
@@ -42,13 +42,6 @@ Styleguide Trumps.Scopes.Header
   border-bottom: 1px solid var(--header-major-border-color);
 }
 
-/* To enlarge height for all screen widths */
-@media (--medium-and-above)  {
-  .s-header {
-      height: 60px;
-  }
-}
-
 /* Affiliation */
 
 /* SEE: ../branding_logos.css */
@@ -77,14 +70,6 @@ Styleguide Trumps.Scopes.Header
     align-items: stretch;
 }
 
-/* On wide viewport, prevent header resize from dynamic content */
-/* CAVEAT: This is only for Portal and Docs which dynamically load content */
-@media (--wide-and-above) {
-  .s-header.navbar {
-    height: 50px;
-  }
-}
-
 .s-header.navbar {
   /* Make horizontal padding match the horizontal content buffer in Portal */
   /* FAQ: The `calc()` keeps track of disparate source of space values */
@@ -95,6 +80,17 @@ Styleguide Trumps.Scopes.Header
 
   background-color: var(--header-bkgd-color);
   padding: var(--nav-padding-vert) var(--nav-padding-horz);
+}
+/* On wide viewport, prevent header resize from dynamic content */
+@media (--medium-and-above) {
+  .s-header.navbar {
+    --logo-height: 60px;
+
+    min-height: var(--logo-height);
+  }
+  .s-header > .navbar-brand {
+    min-height: calc( var(--logo-height) - var(--nav-padding-vert) * 2 );
+  }
 }
 
 /* Navigation: Links */


### PR DESCRIPTION
## Overview

- Resolve migration mistake we didn't catch — near duplicate code.
- Fix edge-case-become-common-case* of dropdown CMS nav overflowing header.

<sup>* Edge-case because most CMS's haven't had the newer Core-Styles yet and TACC has used navbar width that avoids the bug. Become-common-case because more CMS's are getting the newer Core-Styles and TACC experienced the bug during development of https://github.com/TACC/tup-ui/pull/416/.</sup>

## Related

- [CMD-79](https://tacc-main.atlassian.net/browse/CMD-79)

## Changes

- **merges** near-duplicate code
- **changes** height to min-height
- **adds** code to avoid logo moving on navbar expand/collapse

## Testing & UI

https://github.com/TACC/Core-Styles/assets/62723358/a0c3728f-6cbe-4d65-9770-5b5eaddf723c

https://github.com/TACC/Core-Styles/assets/62723358/325a7b72-c6dc-45ab-b264-caffa80656f1