### PR TITLE
fix: CMD-105 overflow on page w/ scrollbar

### DIFF
--- a/src/lib/_imports/objects/o-section.css
+++ b/src/lib/_imports/objects/o-section.css
@@ -159,6 +159,7 @@
 
   /* To size image to cover section dimensions but maintain ratio */
   /* CAVEAT: This causes image to overflow beyond section */
+  /* TODO: Try `max-width: 100%` as in Core-Styles#329 */
   /* CAVEAT: The `vw` causes shrinkage on screen narrower than body min-width */
   /* SEE: "Tricks" section */
   width: 100vw;

--- a/src/lib/_imports/trumps/s-hero-banner.css
+++ b/src/lib/_imports/trumps/s-hero-banner.css
@@ -6,6 +6,7 @@
   .s-home-banner {
     height: 55.5rem;
     width: 100vw;
+    max-width: 100%;
     display: block;
   }
 }


### PR DESCRIPTION
## Overview

Fix `s-home-banner` page overflow.

## Related

- [CMD-105](https://tacc-main.atlassian.net/browse/CMD-105)
- fixes #324

## Changes

- **added** style to prevent overflow

## Testing

1. Open https://dev.cep.tacc.utexas.edu/.
2. Make page have vertical scrollbar.
3. Notice page has horizontal scrollbar.
4. Add `max-width: 100%` as in this PR.
3. Notice horizontal scrollbar disappears.

## UI

https://github.com/TACC/Core-Styles/assets/62723358/ee4b7b99-72ad-4105-af62-480242713b62