### PR TITLE
feat: wp-280 add "ifno" helper for default values

### DIFF
--- a/fractal.config.js
+++ b/fractal.config.js
@@ -98,6 +98,10 @@ engine.handlebars.registerHelper('eq', function(a, b) {
 engine.handlebars.registerHelper('has', function(array, item) {
   return array.includes(item);
 });
+engine.handlebars.registerHelper('ifno', function(value, fallback) {
+  const output = value || fallback;
+  return new engine.handlebars.SafeString(output);
+});
 
 // Export
 module.exports = fractal;

--- a/src/lib/_imports/_partials/message.hbs
+++ b/src/lib/_imports/_partials/message.hbs
@@ -1,9 +1,9 @@
 <{{#if tag}}{{ tag }}{{else}}div{{/if}}
   class="
-    c-message
-    {{#if type}}c-message--type-{{ type }}{{/if}}
-    {{#if scope}}c-message--scope-{{ scope }}{{/if}}
-    {{#unless scope}}c-message--scope-global{{/unless}}
+    {{ifno ns 'c-'}}message
+    {{#if type}}{{ifno ns 'c-'}}message--type-{{ type }}{{/if}}
+    {{#if scope}}{{ifno ns 'c-'}}message--scope-{{ scope }}{{/if}}
+    {{#unless scope}}{{ifno ns 'c-'}}message--scope-global{{/unless}}
   "
 >
 


### PR DESCRIPTION
## Overview

Add & Use new helper `ifno` to support default values.

## Related

- required by #333

## Changes

- **add** helper `ifno`
- **use** helper `ifno` for `c-message`

## Testing

1. Verify `c-message` class is still rendered in HTML in "C Message" demo.

## UI

<img width="1440" alt="ifno" src="https://github.com/TACC/Core-Styles/assets/62723358/10cf844b-538a-4779-b736-2b95d3fdf3a6">
