### PR TITLE
chore: des-2472 no need to align c-app-card icon

### DIFF
--- a/src/lib/_imports/components/c-app-card.css
+++ b/src/lib/_imports/components/c-app-card.css
@@ -42,13 +42,6 @@
 
 
 
-/* Title */
-:--c-app-card__title > .icon {
-  vertical-align: middle;
-}
-
-
-
 /* Types */
 :--c-app-card__types {
   display: flex;


### PR DESCRIPTION
## Overview

Do **not** align icon in `c-app-card__title`.

## Status

> [!IMPORTANT]
> Closed, because `.icon` needs alignment to look "good". The client DesignSafe-CI/portal uses .ds-icon` which does not need such alignment. If it uses different iconset, than it is free to disregard this style, which is still valid and should not be deleted.

## Related

- [DES-2472](https://tacc-main.atlassian.net/browse/DES-2472)
- https://github.com/DesignSafe-CI/portal/pull/1221

## Changes

- **removed** icon alignment

## Testing

1. …

## UI

…