### PR TITLE
feat: CMD-143 deprecate most CMS document style class names

### DIFF
--- a/src/lib/_imports/core-styles.docs.css
+++ b/src/lib/_imports/core-styles.docs.css
@@ -31,10 +31,3 @@
 @import url("./components/c-card.css");
 @import url("./components/c-card--docs.css");
 @import url("./components/tacc-docs.css");
-
-/* TRUMPS */
-/* These styles from retired Core-CMS doc pages might be useful */
-/* ./trumps/s-document.css */
-/* ./trumps/s-guide-doc.css */
-/* ./trumps/s-inline-dl.css */
-/* ./trumps/u-nested-text-content.css */

--- a/src/lib/_imports/trumps/s-document.css
+++ b/src/lib/_imports/trumps/s-document.css
@@ -1,5 +1,5 @@
 /*
-Document
+(DEPRECATED) Document
 
 Styles for elements within a document page or section
 

--- a/src/lib/_imports/trumps/s-guide-doc.css
+++ b/src/lib/_imports/trumps/s-guide-doc.css
@@ -21,6 +21,30 @@ Styleguide Trumps.Scopes.GuideDoc
   text-align: center;
 }
 
+/* ELEMENTS: Description List */
+
+.s-guide-doc dt {
+  display: block;
+  float: left;
+
+  /* Remove space between <dt> and <dd> (from our styles) */
+  /* SEE: ../elments/html-elements.html */
+  margin-bottom: 0;
+
+  font-weight: var(--bold);
+}
+.s-guide-doc dt::after {
+  content: ':';
+
+  margin-inline-end: 0.25em;
+}
+.s-guide-doc dd {
+  clear: right;
+
+  /* Remove space between <dd>'s (from Bootstrap) */
+  margin-bottom: 0;
+}
+
 
 
 

--- a/src/lib/_imports/trumps/s-inline-dl.css
+++ b/src/lib/_imports/trumps/s-inline-dl.css
@@ -1,5 +1,5 @@
 /*
-"Inline" Description List
+(DEPRECATED) "Inline" Description List
 
 Of `<dl>` (description lists), make terms in-line with descritpions.
 

--- a/src/lib/_imports/trumps/u-nested-text-content.css
+++ b/src/lib/_imports/trumps/u-nested-text-content.css
@@ -1,5 +1,5 @@
 /*
-Nested Text Content
+(DEPRECATED) Nested Text Content
 
 Any content that should be nested like a list (`<ol>`, `<ul>`) would be.
 


### PR DESCRIPTION
## Overview

Deprecate these classes:
- `s-document`
- `s-inline-dl`
- `u-nested-text-content`

<sup>Clients should remove them and use only `.s-guide-doc` wrapper.</sup>

Update this class to take over:
- `s-guide-doc`

<sup>Added styles from deprecated classes but used markup in selectors.</sup>

## Related

- [CMD-143](https://tacc-main.atlassian.net/browse/CMD-143)
- required by …

## Changes

- **commented** "(DEPRECATED)" on some files
- **deleted** comments to consider using some files
- **migrated** deprecated styles (that are not already in `s-guide-doc`)

## Testing & UI

Skipped.