### PR TITLE
feat: shouldLoadBootstrap5

### DIFF
--- a/src/lib/_imports/_preview.hbs
+++ b/src/lib/_imports/_preview.hbs
@@ -26,6 +26,14 @@
 </style>
 {{/unless}}
 {{/if}}
+{{#if _target.context.shouldLoadBootstrap5 }}
+{{#unless _target.context.shouldSkipBootstrap5 }}
+<!-- Styles: Global (for current pattern): Bootstrap -->
+<style>
+  @import url('https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css') layer(foundation);
+</style>
+{{/unless}}
+{{/if}}
 
 <!-- Styles: Global (for every pattern) -->
 {{> @import-client-styles styles=globalStyles }}


### PR DESCRIPTION
## Overview

Add `shouldLoadBootstrap5`. Not used yet.

## Related

- required by #___

## Changes

- **added** `shouldLoadBootstrap5` context option

## Testing

Verify [the CDN URL to the stylesheet](https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css) loads.

Otherwise tested via #__.

## UI

Skipped