### PR TITLE
feat: wp-280 use @mixin, deprecate @extend - round 2

### DIFF
--- a/src/lib/_imports/components/c-form.css
+++ b/src/lib/_imports/components/c-form.css
@@ -31,7 +31,7 @@
 
 /* Fields */
 /* IDEA: Make fieldset-child <div>s be opt-out automatic field-wrappers.
-    0. [ ] Define `fieldset > div { @extend :--form__field; }` ruleset.
+    0. [ ] Define `fieldset > div { @mixin :--form__field; }` ruleset.
     1. [ ] Create `:--form--no-auto-wrappers`.
     2. [ ] Define `:--form:where(:not(:--form--no-auto-wrappers)) fieldset > div` rules.
 */


### PR DESCRIPTION
## Overview

Use more `@mixin`. Deprecate more `@extend`.

### Status

- mixins:
    - [ ] forms using `c-message`
    - [ ] `tabs`
    - [ ] `layout`
    - [ ] `tabs`
    - [ ] `grid`
    - [ ] `figure`
    - [ ] `center`
    - [ ] `blockquote`
- review:
    - [ ] author "Testing"
    - [ ] author "UI"
- clients:
    - [ ] test some backwards compatibility
    - [ ] review updates necessary to abandon `@extend`

## Related

- [WP-280](https://tacc-main.atlassian.net/browse/WP-280)
- continues #333

## Changes / Testing / UI

- …