### PR TITLE
feat: drop-cap mixin

### DIFF
--- a/dist/tools/x-drop-cap.css
+++ b/dist/tools/x-drop-cap.css
@@ -1,0 +1,1 @@
+/*! @tacc/core-styles 2.30.1+ | MIT | github.com/TACC/Core-Styles */

--- a/dist/tools/x-drop-cap.demo.css
+++ b/dist/tools/x-drop-cap.demo.css
@@ -1,0 +1,1 @@
+/*! @tacc/core-styles 2.30.1+ | MIT | github.com/TACC/Core-Styles */@supports (initial-letter:3){#demo .x-drop-cap:first-letter{initial-letter:3;padding-right:1em}}@supports (-webkit-initial-letter:3){#demo .x-drop-cap--webkit:first-letter{-webkit-initial-letter:3;font-family:Arial;padding-right:1em}}

--- a/src/lib/_imports/tools/x-drop-cap.css
+++ b/src/lib/_imports/tools/x-drop-cap.css
@@ -1,0 +1,14 @@
+@define-mixin drop-cap {
+  @supports (initial-letter: 3) {
+    padding-right: 1em;
+    initial-letter: 3;
+  }
+}
+
+@define-mixin drop-cap--webkit {
+  @supports (-webkit-initial-letter: 3) {
+    padding-right: 1em;
+    -webkit-initial-letter: 3;
+    font-family: Arial;
+  }
+}

--- a/src/lib/_imports/tools/x-drop-cap.demo.css
+++ b/src/lib/_imports/tools/x-drop-cap.demo.css
@@ -1,0 +1,13 @@
+@import url("./x-drop-cap.css");
+
+/* FAQ: Wrapped to deter clients from using `.x-message` */
+/* HACK: Not in `x-message/demo.css` because it is not processed */
+#demo {
+  .x-drop-cap::first-letter {
+    @mixin drop-cap;
+  }
+
+  .x-drop-cap--webkit::first-letter {
+    @mixin drop-cap--webkit;
+  }
+}

--- a/src/lib/_imports/tools/x-drop-cap/config.yml
+++ b/src/lib/_imports/tools/x-drop-cap/config.yml
@@ -1,0 +1,4 @@
+status: ready
+context:
+  supportStyles:
+    - ../../assets/tools/x-drop-cap.demo.css

--- a/src/lib/_imports/tools/x-drop-cap/readme.md
+++ b/src/lib/_imports/tools/x-drop-cap/readme.md
@@ -1,0 +1,3 @@
+Create a "drop-cap", [a type of an initial](https://en.wikipedia.org/wiki/Initial#Types_of_initial), a letter at the beginning of a word, a chapter, or a paragraph that is larger than the rest of the text.
+
+<script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/tools/x-drop-cap/x-drop-cap.hbs
+++ b/src/lib/_imports/tools/x-drop-cap/x-drop-cap.hbs
@@ -1,0 +1,6 @@
+<dl>
+  <dt>Using <code>initial-letter</code></dt>
+  <dd><p class="x-drop-cap">The first letter of this sentence will be a drop-cap on modern updated browsers. {{> @text-of-one-paragraph-short }}</p></dd>
+  <dt>Using <code>-webkit-initial-letter</code></dt>
+  <dd><p class="x-drop-cap--webkit">The first letter of this sentence should be a drop-cap on most browsers. {{> @text-of-one-paragraph-short }}</p></dd>
+</dl>

--- a/src/lib/_imports/trumps/s-drop-cap.css
+++ b/src/lib/_imports/trumps/s-drop-cap.css
@@ -1,14 +1,6 @@
-@supports (initial-letter: 3){
-  .s-drop-cap > p:first-of-type::first-letter {
-    padding-right: 1em;
-    initial-letter: 3;
-  }
-}
+@import url("../tools/x-drop-cap.css");
 
-@supports (-webkit-initial-letter: 3) {
-  .s-drop-cap > p:first-of-type::first-letter {
-    padding-right: 1em;
-    -webkit-initial-letter: 3;
-    font-family: Arial;
-  }
+.s-drop-cap > p:first-of-type::first-letter {
+  @mixin drop-cap;
+  @mixin drop-cap--webkit;
 }


### PR DESCRIPTION
## Overview

Add `drop-cap` as a mixin.

## Related

None

## Changes

- **added** `drop-cap` mixin and demo
- **used** `drop-cap` mixin for `s-drop-cap`

## Testing & UI

| | [`s-drop-cap`](http://localhost:3000/components/preview/s-drop-cap) | [`x-drop-cap`](http://localhost:3000/components/preview/x-drop-cap) |
| - | - | - |
| chromium | <img alt="chromium s" src="https://github.com/user-attachments/assets/baf1bb3d-d349-40ab-8766-42c3136b905b"> | <img alt="chromium x" src="https://github.com/user-attachments/assets/b01c12ab-5513-4c65-9049-c191beb086ae"> |
| webkit | <img alt="safari s" src="https://github.com/user-attachments/assets/05457e28-f2d1-4cf0-8e57-8352b83e85a3"> | <img alt="safari x" src="https://github.com/user-attachments/assets/a0786dee-07f9-473f-a758-625838e0b3bc"> |