### PR TITLE
feat: support postcss-import-url if configured

### DIFF
--- a/src/bin/config.js
+++ b/src/bin/config.js
@@ -26,7 +26,7 @@ function config(customConfigFiles = [], cssVersion) {
   // Initialize final config file
   emptyOrCreateFile(NEW_CONFIG_FILE);
 
-  // Manipulate config order
+  // Manipulate final config
   configFiles.forEach((nextFile) => {
     const testJson = getConfigObject(nextFile);
 


### PR DESCRIPTION
## Overview

If `postcss-import-url` plugin is in **any** config file, then move it to the **front** of the final config.

<details><summary>Why?</summary>

If `postcss-import-url` is not at the front of the final config (like `postcss-import` is), then remote content it imports will **not** be parsed by plugins configured **before** it.

</details>

## Related

- required by https://github.com/TACC/Core-CMS-Custom/pull/293

## Changes

- **added** logic to conditionally add a config object
- **added** logic to conditionally modify a config object

## Testing

1. Have client add `postcss-import-url`.
2. Verify final config has `postcss-import-url` hoisted to top.

## UI

Tested via https://github.com/TACC/Core-CMS-Custom/pull/293.