### PR TITLE
feat: WP-280 @mixin overlay

### DIFF
--- a/src/lib/_imports/tools/x-overlay.css
+++ b/src/lib/_imports/tools/x-overlay.css
@@ -10,13 +10,19 @@ Styleguide Tools.Mixins.Overlay
 */
 @design-tokens url('../../tokens/v2.json') format('style-dictionary3');
 
-%x-overlay--curtain {
+@define-mixin overlay--curtain {
   color: inherit;
   background-color: rgb( from design-token('color.gray.medium') r g b / 0.65 );
   backdrop-filter: blur(6px);
 }
+%x-overlay--curtain {
+  @mixin overlay--curtain;
+}
 
-%x-overlay--callout {
+@define-mixin overlay--callout {
   color: inherit;
   background-color: rgb( from design-token('color.gray.medium') r g b / 0.90 );
+}
+%x-overlay--callout {
+  @mixin overlay--curtain;
 }


### PR DESCRIPTION
## Overview

Allow using `overlay` as a mixin.

## Related

- [WP-280](https://tacc-main.atlassian.net/browse/WP-280)
- expected by https://github.com/TACC/Core-CMS-Custom/pull/293

## Changes

- **added** `@mixin overlay--…`
- **deprecated** `@extend %x-overlay--…`

## Testing

Tested via https://github.com/TACC/Core-CMS-Custom/pull/293.

## UI

See https://github.com/TACC/Core-CMS-Custom/pull/293.