### PR TITLE
epic/v3: allow dev to build file(s) in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,12 @@ npm run build:css
 npm run build:css -- --build-id="..."
 ```
 
+##### Build Individual Stylesheets
+
+```bash
+npm run build:each -- src/lib/_imports/components/align.postcss src/lib/_imports/components/admonition.postcss ...
+```
+
 
 ## Testing
 

--- a/bin/build-each.js
+++ b/bin/build-each.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+/** Build one stylesheet via the Core-Styles API */
+
+const { buildStylesheets } = require('../src/main');
+
+const inputs = process.argv.slice( 2 );
+
+/* Theme: (default) */
+inputs.forEach( input => {
+    buildStylesheets( input, undefined, './dist');
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "start": "fractal start --sync",
     "build": "npm run build:css && npm run build:demo",
     "build:css": "bin/build.js --build-id=$npm_config_build_id",
+    "build:each": "bin/build-each.js",
     "build:tokens": "bin/build-tokens.js",
     "postbuild:css": "rm -rf dist/fonts && cp -r src/lib/fonts dist/fonts",
     "prebuild:demo": "rm -rf dist/_utils && cp -r src/lib/_utils dist/_utils",

--- a/src/bin/build-styles.js
+++ b/src/bin/build-styles.js
@@ -2,6 +2,7 @@
 
 /** Export internal function used by this package to build styles */
 
+const path = require('path');
 const cmd = require('node-cmd');
 
 // SEE: https://stackoverflow.com/a/63530170
@@ -19,15 +20,18 @@ process.env.FORCE_COLOR = true;
  */
 function build(input, output, opts = {}) {
   // Get data
+  const outDir = output || path.dirname(input);
   const configDir = opts.configDir || `${__dirname}/../`;
   const verbose = opts.verbose === true ? '--verbose' : '';
   const base = opts.baseMirrorDir ? `--base "${opts.baseMirrorDir}"` : '';
   const ext = opts.fileExt ? `--ext "${opts.fileExt}"` : '';
 
   // Build command
-  const command = `postcss "${input}" --dir "${output}" ${verbose} --config "${configDir}" ${base} ${ext}`;
+  const command = `postcss "${input}" --dir "${outDir}" ${verbose} --config "${configDir}" ${base} ${ext}`;
 
-  console.log(`Building stylesheet(s) to ${output}`);
+  const outDirLog = output ? ` to ${output}` : ``;
+  console.log(`Building stylesheet(s)`, outDirLog);
+  if (opts.verbose) console.log('>', command);
 
   // Run command
   cmd.runSync(command);

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,7 @@ const version = require('./bin/version.js');
 /**
  * Build stylesheets from source CSS
  * @param {string} input - Parse CSS files from which directory
- * @param {string} output - Output CSS files to which directory
+ * @param {string|undefined} output - Output CSS files to which directory
  * @param {object} [opts={}] - Options
  * @param {string} [opts.baseMirrorDir] - Path to NOT add when mirroring
  * @param {string} [opts.fileExt] - Custom file extension for output files
@@ -30,7 +30,7 @@ function buildStylesheets(input, output, opts = {}) {
   };
 
   const inputResolved = resolve(input);
-  const outputResolved = resolve(output);
+  const outputResolved = output ? resolve(output) : output;
   const customConfigs = opts.customConfigs
     ? opts.customConfigs.map((filePath) =>
         filePath ? resolve(filePath) : null


### PR DESCRIPTION
## Overview

Allow developers to build a file in place.

## Changes

- **added** `npm run build-each` (`/bin/build-each.js`)

## Testing

### Feature

1. Run `npm run build:each -- src/lib/_imports/components/align.postcss src/lib/_imports/components/admonition.postcss`.
2. Verify two files are built and minified:
    - `src/lib/_imports/components/align.css`
    - `src/lib/_imports/components/admonition.postcss`

### Regression

0. If present, delete `/dist`.
1. Run `npm run build:css`.
2. Verify no errors.
3. Verify `/dist` is created (with all its regular content).

## UI

Skipped.