### PR TITLE
fix(demo): Bootstrap patterns loads v3 instead of v4

### DIFF
--- a/src/lib/_imports/_preview.hbs
+++ b/src/lib/_imports/_preview.hbs
@@ -14,7 +14,7 @@
 {{#unless _target.context.shouldSkipBootstrap }}
 <!-- Styles: Global (for current pattern): Bootstrap -->
 <style>
-  @import url('https://stackpath.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css') layer(foundation);
+  @import url('https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css') layer(foundation);
 </style>
 {{/unless}}
 {{/if}}


### PR DESCRIPTION
## Overview

"Bootstrap" patterns are not loading Bootstrap 4, but instead Bootstrap 3.

## Related

- fixes #346

## Changes

- **changed** version of file from CDN

## Testing

Verify Bootstrap 4 is loaded, not Bootstrap 3, on most Bootstrap patterns.

## UI

Skipped.