### PR TITLE
enhance: c-show-more.js as module

### DIFF
--- a/src/lib/_imports/components/c-show-more/c-show-more--generated.hbs
+++ b/src/lib/_imports/components/c-show-more/c-show-more--generated.hbs
@@ -1,3 +1,9 @@
+<script type="module">
+  import { generateMarkup } from '../raw/c-show-more/c-show-more.js';
+
+  generateMarkup();
+</script>
+
 <h3>Using Generated Markup</h3>
 <p>JavaScript will convert static markup into a full component structure.</p>
 

--- a/src/lib/_imports/components/c-show-more/c-show-more.js
+++ b/src/lib/_imports/components/c-show-more/c-show-more.js
@@ -1,9 +1,11 @@
+export const DEFAULT_ELEMENTS = document.querySelectorAll(`
+  [class*="js-show-more--"]
+`);
+
 /**
  * Convert elements with js-show-more--* classes into show-more components
  */
-function initShowMore() {
-  const elements = document.querySelectorAll('[class*="js-show-more--"]');
-
+export function generateMarkup(elements = DEFAULT_ELEMENTS) {
   [...elements].forEach((element, index) => {
     const wrapper = document.createElement('div');
     wrapper.className = element.className.replace('js-show-more--', 'c-show-more c-show-more--');
@@ -32,5 +34,3 @@ function initShowMore() {
     element.replaceWith(wrapper);
   });
 }
-
-document.addEventListener('DOMContentLoaded', initShowMore); 


### PR DESCRIPTION
## Overview

Convert `c-show-more.js` to a JavaScript module (instead of an auto-run script).

## Related

- enhances #439

## Changes

- **updates** `c-show-more.js` to export function and default parameter
- **deletes** auto-run of `c-show-more.js` function
- **creates** script in "C Show More" demo to load and run `c-show-more.js`

## Testing

1. Visit http://localhost:3000/components/detail/c-show-more--generated.
2. Test "Show Less" / "Show More" links.

## UI

https://github.com/user-attachments/assets/11e7c312-14b6-43e0-8dac-c54e86e0bb33