### PR TITLE
fix: c-show-more.js can create undesirable tag

### DIFF
--- a/src/lib/_imports/components/c-show-more.css
+++ b/src/lib/_imports/components/c-show-more.css
@@ -13,6 +13,7 @@ Styleguide: Components.ShowMore
 */
 @import url("../tools/x-truncate.css");
 
+
 /* Truncation */
 
 /* Many Lines */
@@ -26,10 +27,13 @@ Styleguide: Components.ShowMore
 /* One Line */
 .c-show-more--one-line .c-show-more__target {
   @mixin truncate--one-line;
+
+  display: block;
 }
 .c-show-more--one-line .c-show-more__state:checked ~ .c-show-more__target {
   @mixin untruncate--one-line;
 }
+
 
 /* Show More / Show Less */
 
@@ -43,6 +47,7 @@ Styleguide: Components.ShowMore
 .c-show-more__state:checked ~ .c-show-more__toggle .c-show-more__off-text {
   display: block;
 }
+
 
 /* Toggle */
 .c-show-more__toggle {

--- a/src/lib/_imports/components/c-show-more/c-show-more--generated.hbs
+++ b/src/lib/_imports/components/c-show-more/c-show-more--generated.hbs
@@ -44,10 +44,11 @@
       <dt>Output:</dt>
       <dd>
         <div class="js-show-more--many-lines">
-        <p>This is a JavaScript-enhanced multi-line example. The markup starts simple, then JavaScript builds the full component structure.</p>
-        <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
-        <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      </div>
+          <p>This is a JavaScript-enhanced multi-line example. The markup starts simple, then JavaScript builds the full component structure.</p>
+          <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+          <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        </div>
+      </dd>
     </dl>
   </dd>
 </dl>

--- a/src/lib/_imports/components/c-show-more/c-show-more.hbs
+++ b/src/lib/_imports/components/c-show-more/c-show-more.hbs
@@ -4,11 +4,11 @@
 <dl>
   <dt>One Line Example</dt>
   <dd>
-    <div class="c-show-more c-show-more--one-line">
+    <p class="c-show-more c-show-more--one-line">
       <input type="checkbox" class="c-show-more__state" id="show-more-1">
-      <p class="c-show-more__target">
+      <span class="c-show-more__target">
         This is a single line of text that will be truncated with an ellipsis when it gets too long for its container width. The full text will be revealed when you click "Show More".
-      </p>
+      </span>
       <label class="c-show-more__toggle" for="show-more-1">
         <span class="c-show-more__on-text">Show More</span>
         <span class="c-show-more__off-text">Show Less</span>

--- a/src/lib/_imports/components/c-show-more/c-show-more.js
+++ b/src/lib/_imports/components/c-show-more/c-show-more.js
@@ -5,9 +5,11 @@ export const DEFAULT_ELEMENTS = document.querySelectorAll(`
 /**
  * Convert elements with js-show-more--* classes into show-more components
  */
-export function generateMarkup(elements = DEFAULT_ELEMENTS) {
+export function generateMarkup(elements = DEFAULT_ELEMENTS, options = {
+  targetTag: undefined,
+}) {
   [...elements].forEach((element, index) => {
-    const wrapper = document.createElement('div');
+    const wrapper = document.createElement(element.tagName);
     wrapper.className = element.className.replace('js-show-more--', 'c-show-more c-show-more--');
 
     const checkbox = document.createElement('input');
@@ -15,7 +17,18 @@ export function generateMarkup(elements = DEFAULT_ELEMENTS) {
     checkbox.className = 'c-show-more__state';
     checkbox.id = `show-more-${index}`;
 
-    const target = document.createElement(element.tagName);
+    let targetTag = options.targetTag;
+    if (!targetTag) {
+      switch (true) {
+        case wrapper.className.includes('--one-line'):
+          targetTag = 'span';
+          break;
+        default:
+          targetTag = 'div';
+      }
+    }
+
+    const target = document.createElement(targetTag);
     target.className = 'c-show-more__target';
     target.innerHTML = element.innerHTML;
 


### PR DESCRIPTION
## Overview

- Respect implicit user tag.
- Respect explicit user tag.
- Sensible default tags.

## Related

- enhances #439

## Changes

- **adds** paramter `options` for `targetTag`
- **changes** script to use sensible default tags
- **fixes** script to use implicit user tag
- **fixes** various relevant markup

## Testing & UI

> [TIP]
> Performed.

> [!WARNING]
> Not recorded.

Basically, use `generateMarkup`'s new parameters