### PR TITLE
fix: header font inconsistent between clients

### DIFF
--- a/src/lib/_imports/trumps/s-header.css
+++ b/src/lib/_imports/trumps/s-header.css
@@ -24,17 +24,12 @@ Styleguide Trumps.Scopes.Header
   --height: 50px;
   --header-major-border-width: 1px;
 
-  font-size: var(--global-font-size--medium); /* NO-R/EM: Overwrite `bootstrap.3.3.7.css` */
+  font-size: 14px; /* NO-R/EM: See `font--cms.css` */
   font-weight: var(--bold);
   letter-spacing: 0.025px; /* 14px * 0.025em equals design-requested 0.35px */
   line-height: 1.4; /* `body` line-height differs between CMS, Portal, Docs */
 
-  /* FAQ: Asssigning this font is only necessary for the User Guide,
-          because it has a different `body` font. Otherwise, this style
-          repeats the CMS and Portal `body` font. But, with this style,
-          the header may be moved to a future page/site without losing font */
-  /* TODO: Find a way to be safe, but not redundant */
-  font-family: var(--global-font-family);
+  font-family: var(--global-font-family--sans--cms);
   /* Copied from Portal (via `body`) */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
## Overview

Header font should be explicit, so that it is consistent across clients.[^1]

[^1]: Portal does not use the same global font family nor the same global font size medium as CMS.

## Related

- to resolve tasks for https://github.com/TACC/Core-Portal/pull/1068

## Changes

* **changes** font family and size from variable to certain

## Testing

1. Open http://localhost:3000/components/detail/s-header--with-branding.
2. Verify font size is 14px.
3. Verify font family is `Benton Sans`.

## UI

<img width="1440" alt="Screenshot 2025-03-03 at 14 25 48" src="https://github.com/user-attachments/assets/4302bb3e-6ad9-431b-bfdc-8e63ced571d4" />