### PR TITLE
enhance: header use Roboto not Benton

### DIFF
--- a/src/lib/_imports/trumps/s-header.css
+++ b/src/lib/_imports/trumps/s-header.css
@@ -29,7 +29,7 @@ Styleguide Trumps.Scopes.Header
   letter-spacing: 0.025px; /* 14px * 0.025em equals design-requested 0.35px */
   line-height: 1.4; /* `body` line-height differs between CMS, Portal, Docs */
 
-  font-family: var(--global-font-family--sans--cms);
+  font-family: var(--global-font-family--sans--portal);
   /* Copied from Portal (via `body`) */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
## Overview

Use free fornt instead of paid font, because a free font is easier to replicate across clients.[^1]

[^1]: TACC/Core-Portal has trouble loading Benton Sans font because of relative paths in Core-Styles and Vite asset handling in Core-Portal; TUP's solution failed on Core-Portal (i tested locally and left no paper trail).

## Related

- fixes final **obvious** bug from https://github.com/TACC/Core-Portal/pull/1068

## Changes

- **changed** font for header

## Testing

1. Open http://localhost:3000/components/detail/s-header--with-branding.
2. Verify font is Roboto.

## UI

<img width="1600" alt="Screenshot 2025-03-03 at 16 47 53" src="https://github.com/user-attachments/assets/bec81381-3477-4347-820a-3d8853399a08" />

## Notes
