### PR TITLE
fix: pagination should inherit font size

### DIFF
--- a/src/lib/_imports/tools/x-pagination.postcss
+++ b/src/lib/_imports/tools/x-pagination.postcss
@@ -15,8 +15,6 @@
 
   margin-bottom: unset; /* overwrites core-styles.base.css */
 
-  font-size: var(--global-font-size--small);
-
   &:is(ol, ul) {
     padding-left: unset;
     list-style: none;


### PR DESCRIPTION
## Overview

Pagination should not set font size; it should inherit.

## Related

- mimics #475

## Notes

Setting font size made pagination smaller in Django CMS blog use case.