### PR TITLE
docs: end changelog maintenance for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased][unreleased]
+## [Releases Since 2.40.0](https://github.com/TACC/Core-Styles/releases)
 
-## [v2.40.0] - 2025-03-04: Pagination
+### What's Changed
+
+- docs: `CHANGELOG.md` should be automated by @wesleyboar in https://github.com/TACC/Core-Styles/issues/477
+
+**Full Changelog**: https://github.com/TACC/Core-Styles/compare/v2.40.0...HEAD
+
+## [2.40.0] - 2025-03-04: Pagination
 
 ### What's Changed
 
@@ -15,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Full Changelog**: https://github.com/TACC/Core-Styles/compare/v2.39.4...v2.40.0
 
-## [v2.39.4] - 2025-03-03: Header Font is Now Roboto Not Benton
+## [2.39.4] - 2025-03-03: Header Font is Now Roboto Not Benton
 
 ### What's Changed
 
@@ -24,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Full Changelog**: https://github.com/TACC/Core-Styles/compare/v2.39.3...v2.39.4
 
-## [v2.39.3] - 2025-03-03: Header UI Inconsistencies Across Clients
+## [2.39.3] - 2025-03-03: Header UI Inconsistencies Across Clients
 
 ### What's Changed
 
@@ -32,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Full Changelog**: https://github.com/TACC/Core-Styles/compare/v2.39.2...v2.39.3
 
-## [v2.39.2] - 2025-03-03: Header Font Consistent Across Clients
+## [2.39.2] - 2025-03-03: Header Font Consistent Across Clients
 
 ### What's Changed
 
@@ -40,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Full Changelog**: https://github.com/TACC/Core-Styles/compare/v2.39.1...v2.39.2
 
-## [v2.39.1] - 2025-02-28: Header Nav Link Space Consistent Across Clients
+## [2.39.1] - 2025-02-28: Header Nav Link Space Consistent Across Clients
 
 ### What's Changed
 
@@ -48,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Full Changelog**: https://github.com/TACC/Core-Styles/compare/v2.39.0...v2.39.1
 
-## [v2.39.0] - 2025-02-14: C-Card-List, Icon Demo & Label, CMS Load C-Show-More
+## [2.39.0] - 2025-02-14: C-Card-List, Icon Demo & Label, CMS Load C-Show-More
 
 ### What's Changed
 
@@ -1373,7 +1379,6 @@ See [2.5.0] instead.
 
 Initial working code. (This code may not work on all environments.)
 
-[unreleased]: https://github.com/TACC/Core-Styles/compare/v2.40.0...HEAD
 [2.40.0]: https://github.com/TACC/Core-Styles/releases/tag/v2.40.0
 [2.39.4]: https://github.com/TACC/Core-Styles/releases/tag/v2.39.4
 [2.39.3]: https://github.com/TACC/Core-Styles/releases/tag/v2.39.3

--- a/bin/release-prepare.sh
+++ b/bin/release-prepare.sh
@@ -14,8 +14,8 @@ if ! command_exists git; then
     exit 1
 fi
 
-# Ensure working directory is clean except for CHANGELOG
-if [ -n "$(git status --porcelain | grep -v 'CHANGELOG.md')" ]; then
+# Ensure working directory is clean
+if [ -n "$(git status --porcelain)" ]; then
     echo "Error: Working directory has unexpected changes. Please commit or stash changes."
     exit 1
 fi
@@ -61,19 +61,13 @@ echo "Building CSS..."
 npm run build:css
 
 # Check for substantial changes
-if [ -n "$(git status --porcelain | grep -v 'CHANGELOG.md' | grep -v '^.. dist/')" ]; then
+if [ -n "$(git status --porcelain | grep -v '^.. dist/')" ]; then
     echo "Warning: Unexpected changes detected in build:"
-    git status --porcelain | grep -v 'CHANGELOG.md' | grep -v '^.. dist/'
+    git status --porcelain | grep -v '^.. dist/'
     echo "Please review changes and create an independent PR if necessary."
     if ! confirm "Continue anyway?"; then
         exit 1
     fi
-fi
-
-# Prompt for CHANGELOG update
-echo "Please update CHANGELOG.md now."
-if ! confirm "Have you updated CHANGELOG.md?"; then
-    exit 1
 fi
 
 # Update version

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -55,7 +55,6 @@ Only appointed team members may release versions.
 1. Verify build is up-to-date:\
     `npm run build:css`\
     <sub>Commit substantial unexpected changes via independent PR.</sub>
-1. Update `CHANGELOG.md`.
 1. Update version via:\
     `npm version vN.N.N`\
     (where `N.N.N` is the version tag)


### PR DESCRIPTION
## Overview

Maintaining `CHANGELOG.md` is a chore. I'm not doing that. I can revive it (with missed entries) when it is automated off of GitHub Releases.

## Changes

- **changed** "unreleased" to "Releases Since 2.40.0"
- **deleted** `CHANGELOG` expectations from release script
- **deleted** `CHANGELOG` expectations from release guide

## Related

- #477