### PR TITLE
refactor(demo): use partials for cards with images

### DIFF
--- a/src/lib/_imports/components/c-card/_c-card--image-contact-group.hbs
+++ b/src/lib/_imports/components/c-card/_c-card--image-contact-group.hbs
@@ -1,0 +1,6 @@
+<section class="c-card-list">
+    <h3 id="card-image-{{variant}}-{{section}}-contact">Contact Card with Image - {{variant}}</h3>
+    {{> @c-card--image position="top" wide=true variant=variant is-staff=true }}
+    {{> @c-card--image position="top" wide=true variant=variant is-staff=true card-link="#" }}
+    {{> @c-card--image position="top" wide=true variant=variant is-staff=true image-link="#" }}
+</section> 

--- a/src/lib/_imports/components/c-card/_c-card--image-contact-group.hbs
+++ b/src/lib/_imports/components/c-card/_c-card--image-contact-group.hbs
@@ -1,5 +1,5 @@
 <section class="c-card-list">
-    <h3 id="card-image-{{variant}}-{{section}}-contact">Contact Card with Image - {{variant}}</h3>
+    <h3 id="card-image-{{variant}}-{{section}}-contact"><code>{{variant}}</code> Contact Card with Image</h3>
     {{> @c-card--image position="top" wide=true variant=variant is-staff=true }}
     {{> @c-card--image position="top" wide=true variant=variant is-staff=true card-link="#" }}
     {{> @c-card--image position="top" wide=true variant=variant is-staff=true image-link="#" }}

--- a/src/lib/_imports/components/c-card/_c-card--image-link-group.hbs
+++ b/src/lib/_imports/components/c-card/_c-card--image-link-group.hbs
@@ -1,0 +1,14 @@
+<section class="c-card-list">
+    <h3 id="card-image-{{variant}}-{{section}}-link">{{variant}} Card Image <strong>{{link_type}}</strong> Link</h3>
+    {{#if is_card_link}}
+        {{> @c-card--image position="top" wide=true variant=variant card-link="#" }}
+        {{> @c-card--image position="bottom" wide=true variant=variant card-link="#" disabled="true" }}
+        {{> @c-card--image position="right" tall=true variant=variant card-link="#" disabled="true" }}
+        {{> @c-card--image position="left" tall=true variant=variant card-link="#" disabled="true" }}
+    {{else}}
+        {{> @c-card--image position="top" wide=true variant=variant image-link="#" }}
+        {{> @c-card--image position="bottom" wide=true variant=variant image-link="#" }}
+        {{> @c-card--image position="right" tall=true variant=variant image-link="#" }}
+        {{> @c-card--image position="left" tall=true variant=variant image-link="#" }}
+    {{/if}}
+</section> 

--- a/src/lib/_imports/components/c-card/_c-card--image-link-group.hbs
+++ b/src/lib/_imports/components/c-card/_c-card--image-link-group.hbs
@@ -1,5 +1,5 @@
 <section class="c-card-list">
-    <h3 id="card-image-{{variant}}-{{section}}-link">{{variant}} Card Image <strong>{{link_type}}</strong> Link</h3>
+    <h3 id="card-image-{{variant}}-{{section}}-link"><code>{{variant}}</code> Card Image <strong>{{link_type}}</strong> Link</h3>
     {{#if is_card_link}}
         {{> @c-card--image position="top" wide=true variant=variant card-link="#" }}
         {{> @c-card--image position="bottom" wide=true variant=variant card-link="#" disabled="true" }}

--- a/src/lib/_imports/components/c-card/_c-card--image-position-group.hbs
+++ b/src/lib/_imports/components/c-card/_c-card--image-position-group.hbs
@@ -1,5 +1,5 @@
 <section class="c-card-list">
-    <h3 id="card-image-{{variant}}-{{section}}">{{variant}} Card Image</h3>
+    <h3 id="card-image-{{variant}}-{{section}}"><code>{{variant}}</code> Card Image</h3>
     {{> @c-card--image position="top" wide=true variant=variant }}
     {{> @c-card--image position="bottom" wide=true variant=variant }}
     {{> @c-card--image position="right" tall=true variant=variant }}

--- a/src/lib/_imports/components/c-card/_c-card--image-position-group.hbs
+++ b/src/lib/_imports/components/c-card/_c-card--image-position-group.hbs
@@ -1,0 +1,7 @@
+<section class="c-card-list">
+    <h3 id="card-image-{{variant}}-{{section}}">{{variant}} Card Image</h3>
+    {{> @c-card--image position="top" wide=true variant=variant }}
+    {{> @c-card--image position="bottom" wide=true variant=variant }}
+    {{> @c-card--image position="right" tall=true variant=variant }}
+    {{> @c-card--image position="left" tall=true variant=variant }}
+</section> 

--- a/src/lib/_imports/components/c-card/_c-card--image-variant-section.hbs
+++ b/src/lib/_imports/components/c-card/_c-card--image-variant-section.hbs
@@ -1,0 +1,4 @@
+{{> @c-card--image-position-group variant=variant section=section }}
+{{> @c-card--image-link-group variant=variant section=section link_type="as" is_card_link=true }}
+{{> @c-card--image-link-group variant=variant section=section link_type="with" is_card_link=false }}
+{{> @c-card--image-contact-group variant=variant section=section }} 

--- a/src/lib/_imports/components/c-card/c-card--images.hbs
+++ b/src/lib/_imports/components/c-card/c-card--images.hbs
@@ -10,236 +10,24 @@
 
 <section class="o-section">
     <h2 id="section--null">Section (Default a.k.a Unstyled a.k.a Transparent)</h2>
-    <section class="c-card-list">
-        <h3 id="card-image-transparent-default">Transparent Card Image</h3>
-        {{> @c-card--image position="top" wide=true variant="transparent" }}
-        {{> @c-card--image position="bottom" wide=true variant="transparent" }}
-        {{> @c-card--image position="right" tall=true variant="transparent" }}
-        {{> @c-card--image position="left" tall=true variant="transparent" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-transparent-default-link">Transparent Card Image <strong>as</strong> Link</h3>
-        {{> @c-card--image position="top" wide=true variant="transparent" card-link="#" }}
-        {{> @c-card--image position="bottom" wide=true variant="transparent" card-link="#" disabled="true" }}
-        {{> @c-card--image position="right" tall=true variant="transparent" card-link="#" disabled="true" }}
-        {{> @c-card--image position="left" tall=true variant="transparent" card-link="#" disabled="true" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-transparent-default-link">Transparent Card Image <strong>with</strong> Link</h3>
-        {{> @c-card--image position="top" wide=true variant="transparent" image-link="#" }}
-        {{> @c-card--image position="bottom" wide=true variant="transparent" image-link="#" }}
-        {{> @c-card--image position="right" tall=true variant="transparent" image-link="#" }}
-        {{> @c-card--image position="left" tall=true variant="transparent" image-link="#" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-transparent-default-contact">Contact Card with Image - Transparent</h3>
-        {{> @c-card--image position="top" wide=true variant="transparent" is-staff=true }}
-        {{> @c-card--image position="top" wide=true variant="transparent" is-staff=true card-link="#" }}
-        {{> @c-card--image position="top" wide=true variant="transparent" is-staff=true image-link="#" }}
-    </section>
-
-    <section class="c-card-list">
-        <h3 id="card-image-plain-default">Plain Card Image</h3>
-        {{> @c-card--image position="top" wide=true variant="plain" }}
-        {{> @c-card--image position="bottom" wide=true variant="plain" }}
-        {{> @c-card--image position="right" tall=true variant="plain" }}
-        {{> @c-card--image position="left" tall=true variant="plain" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-plain-default-link">Plain Card Image <strong>as</strong> Link</h3>
-        {{> @c-card--image position="top" wide=true variant="plain" card-link="#" }}
-        {{> @c-card--image position="bottom" wide=true variant="plain" card-link="#" disabled="true" }}
-        {{> @c-card--image position="right" tall=true variant="plain" card-link="#" disabled="true" }}
-        {{> @c-card--image position="left" tall=true variant="plain" card-link="#" disabled="true" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-plain-default-link">Plain Card Image <strong>with</strong> Link</h3>
-        {{> @c-card--image position="top" wide=true variant="plain" image-link="#" }}
-        {{> @c-card--image position="bottom" wide=true variant="plain" image-link="#"}}
-        {{> @c-card--image position="right" tall=true variant="plain" image-link="#" }}
-        {{> @c-card--image position="left" tall=true variant="plain" image-link="#" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-plain-default-contact">Contact Card with Image - Plain</h3>
-        {{> @c-card--image position="top" wide=true variant="plain" is-staff=true }}
-        {{> @c-card--image position="top" wide=true variant="plain" is-staff=true card-link="#" }}
-        {{> @c-card--image position="top" wide=true variant="plain" is-staff=true image-link="#" }}
-    </section>
+    {{> @c-card--image-variant-section variant="transparent" section="default" }}
+    {{> @c-card--image-variant-section variant="plain" section="default" }}
 </section>
 <hr>
 <section class="o-section o-section--style-light">
     <h2 id="section--light">Section - Light</h2>
-    <section class="c-card-list">
-        <h3 id="card-image-transparent-light">Transparent Card Image</h3>
-        {{> @c-card--image position="top" wide=true variant="transparent" }}
-        {{> @c-card--image position="bottom" wide=true variant="transparent" }}
-        {{> @c-card--image position="right" tall=true variant="transparent" }}
-        {{> @c-card--image position="left" tall=true variant="transparent" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-transparent-light-link">Transparent Card Image <strong>as</strong> Link</h3>
-        {{> @c-card--image position="top" wide=true variant="transparent" card-link="#" }}
-        {{> @c-card--image position="bottom" wide=true variant="transparent" card-link="#" disabled="true" }}
-        {{> @c-card--image position="right" tall=true variant="transparent" card-link="#" disabled="true" }}
-        {{> @c-card--image position="left" tall=true variant="transparent" card-link="#" disabled="true" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-transparent-light-link">Transparent Card Image <strong>with</strong> Link</h3>
-        {{> @c-card--image position="top" wide=true variant="transparent" image-link="#" }}
-        {{> @c-card--image position="bottom" wide=true variant="transparent" image-link="#" }}
-        {{> @c-card--image position="right" tall=true variant="transparent" image-link="#" }}
-        {{> @c-card--image position="left" tall=true variant="transparent" image-link="#" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-transparent-light-contact">Contact Card with Image - Transparent</h3>
-        {{> @c-card--image position="top" wide=true variant="transparent" is-staff=true }}
-        {{> @c-card--image position="top" wide=true variant="transparent" is-staff=true card-link="#" }}
-        {{> @c-card--image position="top" wide=true variant="transparent" is-staff=true image-link="#" }}
-    </section>
-
-    <section class="c-card-list">
-        <h3 id="card-image-plain-light">Plain Card Image</h3>
-        {{> @c-card--image position="top" wide=true variant="plain" }}
-        {{> @c-card--image position="bottom" wide=true variant="plain" }}
-        {{> @c-card--image position="right" tall=true variant="plain" }}
-        {{> @c-card--image position="left" tall=true variant="plain" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-plain-light-link">Plain Card Image <strong>as</strong> Link</h3>
-        {{> @c-card--image position="top" wide=true variant="plain" card-link="#" }}
-        {{> @c-card--image position="bottom" wide=true variant="plain" card-link="#" disabled="true" }}
-        {{> @c-card--image position="right" tall=true variant="plain" card-link="#" disabled="true" }}
-        {{> @c-card--image position="left" tall=true variant="plain" card-link="#" disabled="true" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-plain-light-link">Plain Card Image <strong>with</strong> Link</h3>
-        {{> @c-card--image position="top" wide=true variant="plain" image-link="#" }}
-        {{> @c-card--image position="bottom" wide=true variant="plain" image-link="#" }}
-        {{> @c-card--image position="right" tall=true variant="plain" image-link="#" }}
-        {{> @c-card--image position="left" tall=true variant="plain" image-link="#" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-plain-light-contact">Contact Card with Image - Plain</h3>
-        {{> @c-card--image position="top" wide=true variant="plain" is-staff=true }}
-        {{> @c-card--image position="top" wide=true variant="plain" is-staff=true card-link="#" }}
-        {{> @c-card--image position="top" wide=true variant="plain" is-staff=true image-link="#" }}
-    </section>
+    {{> @c-card--image-variant-section variant="transparent" section="light" }}
+    {{> @c-card--image-variant-section variant="plain" section="light" }}
 </section>
 <hr>
 <section class="o-section o-section--style-muted">
     <h2 id="section--muted">Section - Muted</h2>
-    <section class="c-card-list">
-        <h3 id="card-image-transparent-muted">Transparent Card Image</h3>
-        {{> @c-card--image position="top" wide=true variant="transparent" }}
-        {{> @c-card--image position="bottom" wide=true variant="transparent" }}
-        {{> @c-card--image position="right" tall=true variant="transparent" }}
-        {{> @c-card--image position="left" tall=true variant="transparent" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-transparent-muted-link">Transparent Card Image <strong>as</strong> Link</h3>
-        {{> @c-card--image position="top" wide=true variant="transparent" card-link="#" }}
-        {{> @c-card--image position="bottom" wide=true variant="transparent" card-link="#" disabled="true" }}
-        {{> @c-card--image position="right" tall=true variant="transparent" card-link="#" disabled="true" }}
-        {{> @c-card--image position="left" tall=true variant="transparent" card-link="#" disabled="true" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-transparent-muted-link">Transparent Card Image <strong>with</strong> Link</h3>
-        {{> @c-card--image position="top" wide=true variant="transparent" image-link="#" }}
-        {{> @c-card--image position="bottom" wide=true variant="transparent" image-link="#" }}
-        {{> @c-card--image position="right" tall=true variant="transparent" image-link="#" }}
-        {{> @c-card--image position="left" tall=true variant="transparent" image-link="#" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-transparent-muted-contact">Contact Card with Image - Transparent</h3>
-        {{> @c-card--image position="top" wide=true variant="transparent" is-staff=true }}
-        {{> @c-card--image position="top" wide=true variant="transparent" is-staff=true card-link="#" }}
-        {{> @c-card--image position="top" wide=true variant="transparent" is-staff=true image-link="#" }}
-    </section>
-
-    <section class="c-card-list">
-        <h3 id="card-image-plain-muted">Plain Card Image</h3>
-        {{> @c-card--image position="top" wide=true variant="plain" }}
-        {{> @c-card--image position="bottom" wide=true variant="plain" }}
-        {{> @c-card--image position="right" tall=true variant="plain" }}
-        {{> @c-card--image position="left" tall=true variant="plain" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-plain-muted-link">Plain Card Image <strong>as</strong> Link</h3>
-        {{> @c-card--image position="top" wide=true variant="plain" card-link="#" }}
-        {{> @c-card--image position="bottom" wide=true variant="plain" card-link="#" disabled="true" }}
-        {{> @c-card--image position="right" tall=true variant="plain" card-link="#" disabled="true" }}
-        {{> @c-card--image position="left" tall=true variant="plain" card-link="#" disabled="true" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-plain-muted-link">Plain Card Image <strong>with</strong> Link</h3>
-        {{> @c-card--image position="top" wide=true variant="plain" image-link="#" }}
-        {{> @c-card--image position="bottom" wide=true variant="plain" image-link="#" }}
-        {{> @c-card--image position="right" tall=true variant="plain" image-link="#" }}
-        {{> @c-card--image position="left" tall=true variant="plain" image-link="#" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-plain-muted-contact">Contact Card with Image - Plain</h3>
-        {{> @c-card--image position="top" wide=true variant="plain" is-staff=true }}
-        {{> @c-card--image position="top" wide=true variant="plain" is-staff=true card-link="#" }}
-        {{> @c-card--image position="top" wide=true variant="plain" is-staff=true image-link="#" }}
-    </section>
+    {{> @c-card--image-variant-section variant="transparent" section="muted" }}
+    {{> @c-card--image-variant-section variant="plain" section="muted" }}
 </section>
 <hr>
 <section class="o-section o-section--style-dark">
     <h2 id="section--dark">Section - Dark</h2>
-    <section class="c-card-list">
-        <h3 id="card-image-transparent-dark">Transparent Card Image</h3>
-        {{> @c-card--image position="top" wide=true variant="transparent" }}
-        {{> @c-card--image position="bottom" wide=true variant="transparent" }}
-        {{> @c-card--image position="right" tall=true variant="transparent" }}
-        {{> @c-card--image position="left" tall=true variant="transparent" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-transparent-dark-link">Transparent Card Image <strong>as</strong> Link</h3>
-        {{> @c-card--image position="top" wide=true variant="transparent" card-link="#" }}
-        {{> @c-card--image position="bottom" wide=true variant="transparent" card-link="#" disabled="true" }}
-        {{> @c-card--image position="right" tall=true variant="transparent" card-link="#" disabled="true" }}
-        {{> @c-card--image position="left" tall=true variant="transparent" card-link="#" disabled="true" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-transparent-dark-link">Transparent Card Image <strong>with</strong> Link</h3>
-        {{> @c-card--image position="top" wide=true variant="transparent" image-link="#" }}
-        {{> @c-card--image position="bottom" wide=true variant="transparent" image-link="#" }}
-        {{> @c-card--image position="right" tall=true variant="transparent" image-link="#" }}
-        {{> @c-card--image position="left" tall=true variant="transparent" image-link="#" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-transparent-dark-contact">Contact Card with Image - Transparent</h3>
-        {{> @c-card--image position="top" wide=true variant="transparent" is-staff=true }}
-        {{> @c-card--image position="top" wide=true variant="transparent" is-staff=true card-link="#" }}
-        {{> @c-card--image position="top" wide=true variant="transparent" is-staff=true image-link="#" }}
-    </section>
-
-    <section class="c-card-list">
-        <h3 id="card-image-plain-dark">Plain Card Image</h3>
-        {{> @c-card--image position="top" wide=true variant="plain" }}
-        {{> @c-card--image position="bottom" wide=true variant="plain" }}
-        {{> @c-card--image position="right" tall=true variant="plain" }}
-        {{> @c-card--image position="left" tall=true variant="plain" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-plain-dark-link">Plain Card Image <strong>as</strong> Link</h3>
-        {{> @c-card--image position="top" wide=true variant="plain" card-link="#" }}
-        {{> @c-card--image position="bottom" wide=true variant="plain" card-link="#" disabled="true" }}
-        {{> @c-card--image position="right" tall=true variant="plain" card-link="#" disabled="true" }}
-        {{> @c-card--image position="left" tall=true variant="plain" card-link="#" disabled="true" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-plain-dark-link">Plain Card Image <strong>with</strong> Link</h3>
-        {{> @c-card--image position="top" wide=true variant="plain" image-link="#" }}
-        {{> @c-card--image position="bottom" wide=true variant="plain" image-link="#" }}
-        {{> @c-card--image position="right" tall=true variant="plain" image-link="#" }}
-        {{> @c-card--image position="left" tall=true variant="plain" image-link="#" }}
-    </section>
-    <section class="c-card-list">
-        <h3 id="card-image-plain-dark-contact">Contact Card with Image - Plain</h3>
-        {{> @c-card--image position="top" wide=true variant="plain" is-staff=true }}
-        {{> @c-card--image position="top" wide=true variant="plain" is-staff=true card-link="#" }}
-        {{> @c-card--image position="top" wide=true variant="plain" is-staff=true image-link="#" }}
-    </section>
+    {{> @c-card--image-variant-section variant="transparent" section="dark" }}
+    {{> @c-card--image-variant-section variant="plain" section="dark" }}
 </section>


### PR DESCRIPTION
## Overview

Use partials for demo of cards with images, instead of one giant template.

## Related

- makes it easier to do #488

## Changes

- **added** partials
- **changed** template to use partials

## Testing

1. Compare http://localhost:3000/components/preview/c-card--images before and after change.
2. They should match.

## UI

| before | after |
| - | - |
| ![before](https://github.com/user-attachments/assets/09a2e9d8-6b1e-49a0-bc7a-f4e37bc877dc) | ![after](https://github.com/user-attachments/assets/969aa5ed-b2b4-41fb-b1e7-4941f43ebc1d) |