### PR TITLE
fix: GH-436 bootstrap container with banner

### DIFF
--- a/src/lib/_imports/trumps/s-hero-banner/config.yml
+++ b/src/lib/_imports/trumps/s-hero-banner/config.yml
@@ -1,2 +1,13 @@
 context:
   shouldLoadCMS: true
+variants:
+  - name: default
+    label: Has Container
+    context:
+      shouldLoadBootstrap: true
+      hasContainer: true
+  - name: no-container
+    label: No Container
+    context:
+      shouldLoadBootstrap: false
+      hasContainer: false

--- a/src/lib/_imports/trumps/s-hero-banner/s-hero-banner.hbs
+++ b/src/lib/_imports/trumps/s-hero-banner/s-hero-banner.hbs
@@ -1,6 +1,8 @@
 
 <div class="s-home-banner">
-    <article>
+    <article
+        {{#if hasContainer}}class="container"{{/if}}
+    >
         <h1>Core Experience Portal</h1>
         <p>The Texas Advanced Computing Center (TACC) provides powerful and intuitive web interfaces that remove technological hurdles.</p>
     </article>


### PR DESCRIPTION
## Overview

Support `.container` with `.s-overlay`.

## Related

- fixes GH-436
- completes [CMD-148](https://tacc-main.atlassian.net/browse/CMD-148)

## Changes

- **adds** conditional `container` class

## Testing

1. Open instances to compare:
    - http://localhost:3000/components/preview/s-hero-banner--no-container
    - http://localhost:3000/components/preview/s-hero-banner--default
2. Resize pages.
3. Notice:
    - `--no-container` has white box that, on medium screens, **does** fill page.
    - `--default` has white box that, on medium screens, does **not** fill page.

## UI

| has container | no container |
| - | - |
| <img width="1024" alt="has-container" src="https://github.com/user-attachments/assets/5505a519-02be-4e1c-a4b9-932d41e9da02" /> | <img width="1024" alt="no-container" src="https://github.com/user-attachments/assets/f7b1f5a5-51e7-4267-a0bd-0f9af2b3f766" /> |

https://github.com/user-attachments/assets/521e1a80-b1cc-4520-821d-0f221ef5e3fb

https://github.com/user-attachments/assets/75ae574e-49bc-45c9-a7b5-dafbf63850f4

