### PR TITLE
docs: fix old confluence links (not all, but most)

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -173,10 +173,10 @@ See [how Core Styles can be used in React with CSS Modules](https://github.com/T
 To _author_ CSS like is done for [Core Styles], follow TACC's [CSS Style Guide].
 
 [core styles]: https://github.com/TACC/Core-Styles
-[css style guide]: https://confluence.tacc.utexas.edu/display/~wbomar/Shared+UI+-+CSS+-+Style+Guide
+[css style guide]: https://tacc-main.atlassian.net/wiki/x/7Bdv
 [foundation]: https://css-tricks.com/reboot-resets-reasoning/
 [react]: https://react.dev/
 
 [^1]: Core-Styles testing with a [reset, normalize, or reboot][foundation] has onyl been atop Bootstrap 4's `reboot.scss`.
 [^2]: If you have access, [report issues in JIRA "WP" Project](https://jira.tacc.utexas.edu/projects/WP/issues). Otherwise, [report issues in Github](https://github.com/TACC/Core-Styles/issues).
-[^3]: Stylesheet load order and naming comes from [MCSS](https://confluence.tacc.utexas.edu/x/b53tDg).
+[^3]: Stylesheet load order and naming comes from [MCSS](https://tacc-main.atlassian.net/wiki/x/hRlv).

--- a/docs/01-index.md
+++ b/docs/01-index.md
@@ -23,8 +23,8 @@ Known Clients:
 [tacc/core-portal]: https://github.com/TACC/Core-Portal
 [@tacc/core-styles]: https://www.npmjs.com/package/@tacc/core-styles
 
-[tacc shared css]: https://confluence.tacc.utexas.edu/x/eJR9E
-[tacc itcss]: https://confluence.tacc.utexas.edu/x/IAA9Cw
+[tacc shared css]: https://tacc-main.atlassian.net/wiki/x/PR1v
+[tacc itcss]: https://tacc-main.atlassian.net/wiki/x/QQhv
 [bootstrap]: https://getbootstrap.com/docs/4.3/
 
 <script type="module">

--- a/src/lib/_imports/README.md
+++ b/src/lib/_imports/README.md
@@ -12,7 +12,7 @@ Styles here should be isolated UI patterns and be imported by other stylesheets.
 
 These directories are based on [ITCSS][tacc-itcss].
 
-[tacc-itcss]: https://confluence.tacc.utexas.edu/x/IAA9Cw
+[tacc-itcss]: https://tacc-main.atlassian.net/wiki/x/QQhv
 
 ## Documentation Format
 
@@ -35,6 +35,6 @@ See [TACC: CSS Style Guide][tacc-style-guide].
 - Most styles will be _only **or** mostly_ for [structure][tacc-oocss].
 - Some styles may be for [skin][tacc-oocss].
 
-[tacc-oocss]: https://confluence.tacc.utexas.edu/x/VwALBg 'TACC: Object-Oriented CSS'
-[tacc-style-guide]: https://confluence.tacc.utexas.edu/x/ZQALBg 'TACC: CSS Style Guide'
+[tacc-oocss]: https://tacc-main.atlassian.net/wiki/x/7Atv 'TACC: Object-Oriented CSS'
+[tacc-style-guide]: https://tacc-main.atlassian.net/wiki/x/7Bdv 'TACC: CSS Style Guide'
 [fractal-docs-guide]: https://fractal.build/guide/components/#what-defines-a-component 'Fractal: User Guide: Components'

--- a/src/lib/_imports/_preview.hbs
+++ b/src/lib/_imports/_preview.hbs
@@ -5,7 +5,7 @@
 
 
 <!-- Styles: Layers -->
-{{!-- https://confluence.tacc.utexas.edu/x/b53tDg --}}
+{{!-- https://tacc-main.atlassian.net/wiki/x/hRlv --}}
 <style>
 @layer foundation, base, project;
 </style>

--- a/src/lib/_imports/components/c-image-map.css
+++ b/src/lib/_imports/components/c-image-map.css
@@ -21,6 +21,6 @@ Styleguide Components.ImageMap
 */
 
 /* Styles are organized by OOCSS methodology */
-/* SEE: https://confluence.tacc.utexas.edu/x/VwALBg */
+/* SEE: https://tacc-main.atlassian.net/wiki/x/6Atv */
 @import url("./c-image-map.structure.css");
 @import url("./c-image-map.skin.css");

--- a/src/lib/_imports/components/c-pill.css
+++ b/src/lib/_imports/components/c-pill.css
@@ -24,7 +24,7 @@
 /* Modifiers - Structure */
 
 /* CAVEAT: This alone may not trigger truncation */
-/* SEE: https://confluence.tacc.utexas.edu/x/sAoFDg */
+/* SEE: https://tacc-main.atlassian.net/wiki/x/6hpv */
 :--c-pill--should-truncate {
   max-width: 100%;
 

--- a/src/lib/_imports/components/c-pill/readme.md
+++ b/src/lib/_imports/components/c-pill/readme.md
@@ -8,6 +8,6 @@ To label the status of something.
 | `.c-pill--is-success`      | `.pill--success`         | for a "success" status
 | `.c-pill--is-...`          | `.pill--...`             | for a "..." status
 
-<small>* Requires client styles, because [truncation can be context-dependent](https://confluence.tacc.utexas.edu/x/sAoFDg).</small>
+<small>* Requires client styles, because [truncation can be context-dependent](https://tacc-main.atlassian.net/wiki/x/6hpv).</small>
 
 <script src="{{path '/assets/_utils/js/open-ext-links-in-new-window.js'}}" />

--- a/src/lib/_imports/components/cortal-icon-font.md
+++ b/src/lib/_imports/components/cortal-icon-font.md
@@ -1,3 +1,3 @@
 # Cortal Icon Font
 
-The file `cortal-icon-font.css` comes from raw CSS provided by latest version of [TACC's "Cortal" icon font](https://confluence.tacc.utexas.edu/x/MCAFDg).
+The file `cortal-icon-font.css` comes from raw CSS provided by latest version of [TACC's "Cortal" icon font](https://tacc-main.atlassian.net/wiki/x/Bg5v).

--- a/src/lib/_imports/components/cortal-icon.css
+++ b/src/lib/_imports/components/cortal-icon.css
@@ -72,7 +72,7 @@ p > :is(:--action) > .icon:first-child {
 /* Overrides */
 
 /* To overwrite `cortal.icon.fonts.css` icon sizes */
-/* SEE: https://confluence.tacc.utexas.edu/x/dgB_CQ */
+/* SEE: https://tacc-main.atlassian.net/wiki/x/Bg5v */
 /* CAVEAT: Assumes 1rem = 10px */
 /* relative units */
 .icon-sm {

--- a/src/lib/_imports/core-styles.base.css
+++ b/src/lib/_imports/core-styles.base.css
@@ -2,7 +2,7 @@
 /* DO NOT ADD STYLES HERE; ONLY IMPORT OTHER STYLESHEETS */
 
 /* Organize via ITCSS */
-/* https://confluence.tacc.utexas.edu/x/IAA9Cw */
+/* https://tacc-main.atlassian.net/wiki/x/QQhv */
 
 /* SETTINGS */
 @import url("./core-styles.settings.css");

--- a/src/lib/_imports/core-styles.cms.css
+++ b/src/lib/_imports/core-styles.cms.css
@@ -2,7 +2,7 @@
 /* DO NOT ADD STYLES HERE; ONLY IMPORT OTHER STYLESHEETS */
 
 /* Organize via ITCSS */
-/* https://confluence.tacc.utexas.edu/x/IAA9Cw */
+/* https://tacc-main.atlassian.net/wiki/x/QQhv */
 
 /* SETTINGS */
 /* To get most settings, client should load `./base.css` first */

--- a/src/lib/_imports/core-styles.demo.css
+++ b/src/lib/_imports/core-styles.demo.css
@@ -2,7 +2,7 @@
 /* DO NOT ADD STYLES HERE; ONLY IMPORT OTHER STYLESHEETS */
 
 /* Organize via ITCSS */
-/* https://confluence.tacc.utexas.edu/x/IAA9Cw */
+/* https://tacc-main.atlassian.net/wiki/x/QQhv */
 
 /* SETTINGS */
 @import url("./settings/demo.css");

--- a/src/lib/_imports/core-styles.docs.css
+++ b/src/lib/_imports/core-styles.docs.css
@@ -2,7 +2,7 @@
 /* DO NOT ADD STYLES HERE; ONLY IMPORT OTHER STYLESHEETS */
 
 /* Organize via ITCSS */
-/* https://confluence.tacc.utexas.edu/x/IAA9Cw */
+/* https://tacc-main.atlassian.net/wiki/x/QQhv */
 
 /* SETTINGS */
 /* To get most settings, client should load `./base.css` first */

--- a/src/lib/_imports/core-styles.header.css
+++ b/src/lib/_imports/core-styles.header.css
@@ -2,7 +2,7 @@
 /* DO NOT ADD STYLES HERE; ONLY IMPORT OTHER STYLESHEETS */
 
 /* Organize via ITCSS */
-/* https://confluence.tacc.utexas.edu/x/IAA9Cw */
+/* https://tacc-main.atlassian.net/wiki/x/QQhv */
 
 /* SETTINGS */
 /* To get these, client should load `./base.css` first */

--- a/src/lib/_imports/core-styles.portal.css
+++ b/src/lib/_imports/core-styles.portal.css
@@ -2,7 +2,7 @@
 /* DO NOT ADD STYLES HERE; ONLY IMPORT OTHER STYLESHEETS */
 
 /* Organize via ITCSS */
-/* https://confluence.tacc.utexas.edu/x/IAA9Cw */
+/* https://tacc-main.atlassian.net/wiki/x/QQhv */
 
 /* SETTINGS */
 /* To get most settings, client should load `./base.css` first */

--- a/src/lib/_imports/core-styles.wysiwyg.css
+++ b/src/lib/_imports/core-styles.wysiwyg.css
@@ -2,7 +2,7 @@
 /* DO NOT ADD STYLES HERE; ONLY IMPORT OTHER STYLESHEETS */
 
 /* Organize via ITCSS */
-/* https://confluence.tacc.utexas.edu/x/IAA9Cw */
+/* https://tacc-main.atlassian.net/wiki/x/QQhv */
 
 /* SETTINGS */
 @import url("./core-styles.settings.css");

--- a/src/lib/_imports/generics/README.md
+++ b/src/lib/_imports/generics/README.md
@@ -6,4 +6,4 @@ This directory is here to show and document all [ITCSS] directories.
 
 [^1]: Bootstrap also provides its own objects, components, elements, and trumps.
 
-[itcss]: https://confluence.tacc.utexas.edu/x/IAA9Cw
+[itcss]: https://tacc-main.atlassian.net/wiki/x/QQhv

--- a/src/lib/_imports/generics/fonts.css
+++ b/src/lib/_imports/generics/fonts.css
@@ -16,7 +16,7 @@ Usage:
 Reference:
 - [Keep Font CSS Simple](https://www.456bereastreet.com/archive/201012/font-face_tip_define_font-weight_and_font-style_to_keep_your_css_simple/)
 - [font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight)
-- [Shared UI - Constants - Font](https://confluence.tacc.utexas.edu/x/cYAZCg)
+- [Shared UI - Constants - Font](https://tacc-main.atlassian.net/wiki/x/XRtv)
 
 Styleguide Generics.Fonts
 */

--- a/src/lib/_imports/settings/font.css
+++ b/src/lib/_imports/settings/font.css
@@ -14,7 +14,7 @@ Usage:
 
 Reference:
 - https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties
-- [Shared UI - Constants - Font](https://confluence.tacc.utexas.edu/x/cYAZCg)
+- [Shared UI - Constants - Font](https://tacc-main.atlassian.net/wiki/x/XRtv)
 
 Styleguide Settings.CustomProperties.Font
 */

--- a/src/lib/_imports/trumps/tacc-search-bar.css
+++ b/src/lib/_imports/trumps/tacc-search-bar.css
@@ -39,7 +39,7 @@ Styleguide Scopes.SearchBar
 :host [part="form"] {
   /* To ensure search field font matches Portal */
   /* GH-101: Set and rely on header font */
-  /* SEE: https://confluence.tacc.utexas.edu/x/nB4FDg */
+  /* SEE: https://tacc-main.atlassian.net/wiki/x/Nw9v */
   font-family: "Roboto";
 
   display: flex;


### PR DESCRIPTION
## Overview

Fix most old Confluence URLs (the ones most likely to be clicked).