### PR TITLE
feat: auto-define accent, 2nd-ary, 3rd-ary colors

### DIFF
--- a/src/lib/_imports/settings/color.accent--auto.css
+++ b/src/lib/_imports/settings/color.accent--auto.css
@@ -1,0 +1,74 @@
+/* To auto-define lighter/darker colors (accent, secondary, tertiary) */
+@supports (color: lab(from white l a b)) {
+    :root {
+        --tc-near-white-l: 0.95;
+        --tc-near-black-l: 0.1;
+    }
+    :root, /* cuz websites default to "light" */
+    :--light-context-safe {
+        --global-color-accent--xxx-light: oklab(from var(--tc-color-1) var(--tc-near-white-l) a b); /* DECPRECATED */
+        --global-color-accent--xx-light: oklab(from var(--tc-color-1) calc(l + (var(--tc-near-white-l) - l) * 3/4) a b);
+        --global-color-accent--x-light: oklab(from var(--tc-color-1) calc(l + (var(--tc-near-white-l) - l) * 2/4) a b);
+        --global-color-accent--light: oklab(from var(--tc-color-1) calc(l + (var(--tc-near-white-l) - l) * 1/4) a b);
+        --global-color-accent--normal: var(--tc-color-1);
+        --global-color-accent--dark: oklab(from var(--tc-color-1) calc(l - (l - var(--tc-near-black-l)) * 1/4) a b);
+        --global-color-accent--x-dark: oklab(from var(--tc-color-1) calc(l - (l - var(--tc-near-black-l)) * 2/4) a b);
+        --global-color-accent--xx-dark: oklab(from var(--tc-color-1) calc(l - (l - var(--tc-near-black-l)) * 3/4) a b);
+        --global-color-accent--xxx-dark: oklab(from var(--tc-color-1) var(--tc-near-black-l) a b);
+
+        --global-color-secondary--xx-light: oklab(from var(--tc-color-2) var(--tc-near-white-l) a b);
+        --global-color-secondary--x-light: oklab(from var(--tc-color-2) calc(l + (var(--tc-near-white-l) - l) * 2/3) a b);
+        --global-color-secondary--light: oklab(from var(--tc-color-2) calc(l + (var(--tc-near-white-l) - l) * 1/3) a b);
+        --global-color-secondary--normal: var(--tc-color-2);
+        --global-color-secondary--dark: oklab(from var(--tc-color-2) calc(l - (l - var(--tc-near-black-l)) * 1/3) a b);
+        --global-color-secondary--x-dark: oklab(from var(--tc-color-2) calc(l - (l - var(--tc-near-black-l)) * 2/3) a b);
+        --global-color-secondary--xx-dark: oklab(from var(--tc-color-2) var(--tc-near-black-l) a b);
+
+        --global-color-tertiary--xx-light: oklab(from var(--tc-color-3) var(--tc-near-white-l) a b);
+        --global-color-tertiary--x-light: oklab(from var(--tc-color-3) calc(l + (var(--tc-near-white-l) - l) * 2/3) a b);
+        --global-color-tertiary--light: oklab(from var(--tc-color-3) calc(l + (var(--tc-near-white-l) - l) * 1/3) a b);
+        --global-color-tertiary--normal: var(--tc-color-3);
+        --global-color-tertiary--dark: oklab(from var(--tc-color-3) calc(l - (l - var(--tc-near-black-l)) * 1/3) a b);
+        --global-color-tertiary--x-dark: oklab(from var(--tc-color-3) calc(l - (l - var(--tc-near-black-l)) * 2/3) a b);
+        --global-color-tertiary--xx-dark: oklab(from var(--tc-color-3) var(--tc-near-black-l) a b);
+
+        /* DEPRECATED */
+        /* To redefine aliases */
+        /* FAQ: Aliases do not auto-update when source vars are overridden */
+        --global-color-accent--secondary: var(--global-color-secondary--normal);
+        --global-color-accent--tertiary: var(--global-color-tertiary--normal);
+    }
+    :--dark-context-safe {
+        --global-color-accent--xxx-light: white; /* DECPRECATED */
+        --global-color-accent--xx-light: oklab(from var(--tc-color-1) var(--tc-near-white-l) a b);
+        --global-color-accent--x-light: oklab(from var(--tc-color-1) calc(l + (var(--tc-near-white-l) - l) * 3/4) a b);
+        --global-color-accent--light: oklab(from var(--tc-color-1) calc(l + (var(--tc-near-white-l) - l) * 2/4) a b);
+        --global-color-accent--normal: oklab(from var(--tc-color-1) calc(l + (var(--tc-near-white-l) - l) * 1/4) a b);
+        --global-color-accent--dark: var(--tc-color-1);
+        --global-color-accent--x-dark: oklab(from var(--tc-color-1) calc(l - (l - var(--tc-near-black-l)) * 1/4) a b);
+        --global-color-accent--xx-dark: oklab(from var(--tc-color-1) calc(l - (l - var(--tc-near-black-l)) * 2/4) a b);
+        --global-color-accent--xxx-dark: oklab(from var(--tc-color-1) calc(l - (l - var(--tc-near-black-l)) * 3/4) a b);
+
+        --global-color-secondary--xx-light: white;
+        --global-color-secondary--x-light: oklab(from var(--tc-color-2) var(--tc-near-white-l) a b);
+        --global-color-secondary--light: oklab(from var(--tc-color-2) calc(l + (var(--tc-near-white-l) - l) * 2/3) a b);
+        --global-color-secondary--normal: oklab(from var(--tc-color-2) calc(l + (var(--tc-near-white-l) - l) * 1/3) a b);
+        --global-color-secondary--dark: var(--tc-color-2);
+        --global-color-secondary--x-dark: oklab(from var(--tc-color-2) calc(l - (l - var(--tc-near-black-l)) * 1/3) a b);
+        --global-color-secondary--xx-dark: oklab(from var(--tc-color-2) calc(l - (l - var(--tc-near-black-l)) * 2/3) a b);
+
+        --global-color-tertiary--xx-light: white;
+        --global-color-tertiary--x-light: oklab(from var(--tc-color-3) var(--tc-near-white-l) a b);
+        --global-color-tertiary--light: oklab(from var(--tc-color-3) calc(l + (var(--tc-near-white-l) - l) * 2/3) a b);
+        --global-color-tertiary--normal: oklab(from var(--tc-color-3) calc(l + (var(--tc-near-white-l) - l) * 1/3) a b);
+        --global-color-tertiary--dark: var(--tc-color-3);
+        --global-color-tertiary--x-dark: oklab(from var(--tc-color-3) calc(l - (l - var(--tc-near-black-l)) * 1/3) a b);
+        --global-color-tertiary--xx-dark: oklab(from var(--tc-color-3) calc(l - (l - var(--tc-near-black-l)) * 2/3) a b);
+
+        /* DEPRECATED */
+        /* To redefine aliases */
+        /* FAQ: Aliases do not auto-update when source vars are overridden */
+        --global-color-accent--secondary: var(--global-color-secondary--normal);
+        --global-color-accent--tertiary: var(--global-color-tertiary--normal);
+    }
+}


### PR DESCRIPTION
## Overview

Set all values accent, secondary, and tertiary colors given normal value of each. Even supports light and dark context.

## Related

- required by https://github.com/TACC/Core-CMS-Custom/pull/502

## Changes

- **adds** a stylesheet

## Testing

0. Open a CMS website that uses Core-Styles library.
1. Define these variables:
    ```css
    :root {
        --tc-color-1: #265e83;
        --tc-color-2: #265e83;
        --tc-color-3: #aecb62;
    }
    ```
2. Import this stylesheet onto a page.
3. Open "Elements" panel in "Developer Tools".
4. Find the colors defined by this file.
5. Verify an accurate range of lightness values.

## UI

…