### PR TITLE
feat: make link text selectable

### DIFF
--- a/src/lib/_utils/js/auto-make-link-text-selectable.js
+++ b/src/lib/_utils/js/auto-make-link-text-selectable.js
@@ -1,13 +1,15 @@
-import makeLinkTextSelectable from './make-link-text-selectable.js';
+import makeLinkContentSelectable from './make-link-text-selectable.js';
 
 const params = Object.values({
   attribute: 'data-text-selectable',
-  textElementQuerySelector: 'p, h1, h2, h3, h4, h5, h6',
+  textElementQuerySelector: '*',
   layer: 'base.allow-override'
 });
 
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', () => makeLinkTextSelectable(...params));
+  document.addEventListener('DOMContentLoaded', () => {
+    makeLinkContentSelectable(...params)
+  });
 } else {
-  makeLinkTextSelectable(...params);
+  makeLinkContentSelectable(...params);
 }

--- a/src/lib/_utils/js/make-link-text-selectable.js
+++ b/src/lib/_utils/js/make-link-text-selectable.js
@@ -2,13 +2,13 @@
  * Makes text selectable within anchor links
  * (applies to existing links and new links)
  * @param {string} [attribute="data-text-selectable"] - The attribute to add to selectable text selectable
- * @param {string|string[]} [textElementQuerySelector='p, h1, h2, h3, h4, h5, h6'] - CSS selector string to match the text elements to make selectable
+ * @param {string|string[]} [contentQuerySelector='*'] - CSS selector string to match the elements to make selectable
  * @param {string} [layer] - A CSS layer to use for styles
  * @returns {Object} An object with a `disable` method to remove the functionality
  */
-export default function makeLinkTextSelectable(
+export default function makeLinkContentSelectable(
   attribute = 'data-text-selectable',
-  textElementQuerySelector = 'p, h1, h2, h3, h4, h5, h6',
+  contentQuerySelector = '*',
   layer
 ) {
   const style = document.createElement('style');
@@ -16,7 +16,7 @@ export default function makeLinkTextSelectable(
           a[${attribute}] {
             display: inline-block;
           }
-          a[${attribute}] :is(${textElementQuerySelector}) {
+          a[${attribute}] :is(${contentQuerySelector}) {
             cursor: text;
             -webkit-user-select: text;
             user-select: text;
@@ -34,7 +34,7 @@ export default function makeLinkTextSelectable(
     link.draggable = false;
     link.setAttribute(attribute, 'true');
 
-    link.querySelectorAll(textElementQuerySelector).forEach(element => {
+    link.querySelectorAll(contentQuerySelector).forEach(element => {
       element.addEventListener('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -43,7 +43,7 @@ export default function makeLinkTextSelectable(
   }
 
   // For present links
-  document.querySelectorAll(`a:has(${textElementQuerySelector})`).forEach(processLink);
+  document.querySelectorAll(`a:has(${contentQuerySelector})`).forEach(processLink);
 
   // For future links
   const observer = new MutationObserver((mutations) => {


### PR DESCRIPTION
## Overview

Allow user to select text elements within a link.

## Changes

- **added** a new utility script
- used by:
    - https://github.com/TACC/Texascale-CMS/pull/21
    - https://github.com/TACC/Core-CMS-Custom/commit/1d15448

## Testing

1. Have a website with text elements inside links.
2. Run the script:
    ```js
    let testScript = document.createElement('script');
    testScript.type = 'module';
    testScript.src ='https://cdn.jsdelivr.net/gh/TACC/Core-Styles@1e2b800a/src/lib/_utils/js/auto-make-link-text-selectable.js';
    document.head.appendChild(testScript);
    ```
3. Verify link text is selectable.
    | browser | result | note |
    | - | - | - |
    | chromium | ✅ | |
    | firefox | ✅ | |
    | opera | ✅ | script is unnecessary |
    | safari | ❌ | tried for too long, gave up |

## UI

### When it Works… and Doesn't

https://github.com/user-attachments/assets/767dfa68-996c-44ce-8120-9f1867d27181

https://github.com/user-attachments/assets/a76d263d-be62-4bae-b067-ad7780b6814b

https://github.com/user-attachments/assets/83080852-4c82-473a-a160-d077e44ac7dc

### Browser Testing

https://github.com/user-attachments/assets/5db8c79f-0f5b-455e-bce4-0730de85b642

https://github.com/user-attachments/assets/942ad39f-be7a-48af-a544-d4c36a927e60

https://github.com/user-attachments/assets/e04fe87f-fc68-451e-8d9b-18645ef2f1ab

> [!WARNING]
> Does not work in Safari.

https://github.com/user-attachments/assets/cada1b3b-4723-4e32-b074-14fb81a0657d