### PR TITLE
fix: make link text selectable

### DIFF
--- a/src/lib/_utils/js/make-link-text-selectable.js
+++ b/src/lib/_utils/js/make-link-text-selectable.js
@@ -32,7 +32,6 @@ export default function makeLinkContentSelectable(
 
   function processLink(link) {
     link.draggable = false;
-    link.setAttribute(attribute, 'true');
 
     link.querySelectorAll(contentQuerySelector).forEach(element => {
       element.addEventListener('click', (e) => {
@@ -43,7 +42,9 @@ export default function makeLinkContentSelectable(
   }
 
   // For present links
-  document.querySelectorAll(`a:has(${contentQuerySelector})`).forEach(processLink);
+  document.querySelectorAll(
+    `a[${attribute}]:has(${contentQuerySelector})`
+  ).forEach(processLink);
 
   // For future links
   const observer = new MutationObserver((mutations) => {


### PR DESCRIPTION
## Overview

#538 applies `data-text-selectable` to all links by default.

Besides being undesired, this causes some links to be ineffectual.

## Related

- fixes #538

## Changes

- **changes** limit link query to those with attribute
- **deletes** command to add attribute

## Testing

1. [Open test page](https://pprd.wtcs.tacc.utexas.edu/wes-demo-for-hedda/?edit).
2. [Update snippet](https://pprd.wtcs.tacc.utexas.edu/admin/djangocms_snippet/snippet/15/change/) to use latest commit from this branch.
3. Verify breadcrumb links navigate browser when clicked.
4. Return to test page.
5. Add `data-text-selectable` on one card link.
6. Verify you can select text on that card link.

## UI

### Before

https://github.com/user-attachments/assets/82622274-c4af-4158-ad4e-47bf0074ae73

### After

https://github.com/user-attachments/assets/f020b04e-00a2-4cb7-992e-69224c379d70

https://github.com/user-attachments/assets/3b1eaba4-0db0-458c-a5ea-e95e0770c7a5