### PR TITLE
fix: make link text selectable kills dynamic links

### DIFF
--- a/src/lib/_utils/js/auto-make-link-text-selectable.js
+++ b/src/lib/_utils/js/auto-make-link-text-selectable.js
@@ -1,9 +1,9 @@
 import makeLinkContentSelectable from './make-link-text-selectable.js';
 
 const params = Object.values({
-  attribute: 'data-text-selectable',
-  textElementQuerySelector: '*',
-  layer: 'base.allow-override'
+  linkAttribute: 'data-text-selectable',
+  linkTextSelector: '*',
+  cssLayer: 'base.allow-override'
 });
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Overview

#538 applies `data-text-selectable` to all dynamically-added links by default.

This causes CMS editor interface links to be ineffectual.

## Related

- fixes #538
- continues #540

## Changes

 **refactors** parameter names & usage
- **changes** limit future link query to those with attribute
- **fixes** command to unprocess links

## Testing

0. Be logged in as admin.
1. [Open test page](https://pprd.wtcs.tacc.utexas.edu/wes-demo-for-hedda/?edit).
2. [Update snippet](https://pprd.wtcs.tacc.utexas.edu/admin/djangocms_snippet/snippet/15/change/) to use latest commit from this branch.
3. Verify breadcrumb links navigate browser when clicked.
4. Return to test page.
5. Add `data-text-selectable` on one card link.
6. Verify you can select text on that card link.
7. Double click image to card content to edit.
8. Click "Link" in breadcrumbs of CMS editor modal.
9. Verify editor modal changes to Link editing.

## UI

### Before

https://github.com/user-attachments/assets/b233c9db-7b33-4f71-96d0-0202fbe8d4dd

### After

https://github.com/user-attachments/assets/09e99d7d-bec0-4602-bc2d-339bcea4f7b5

https://github.com/user-attachments/assets/ec317a9e-51da-46be-99cd-d9a0dbcadf5a

https://github.com/user-attachments/assets/563e3480-bca6-4318-9f1a-a18230d63329