### PR TITLE
feat: output command during verbose build

### DIFF
--- a/src/bin/build-styles.js
+++ b/src/bin/build-styles.js
@@ -27,7 +27,11 @@ function build(input, output, opts = {}) {
   // Build command
   const command = `postcss "${input}" --dir "${output}" ${verbose} --config "${configDir}" ${base} ${ext}`;
 
-  console.log(`Building stylesheet(s) to ${output}`);
+  if (verbose) {
+    console.log(`Building stylesheet(s) to ${output} via command:\n`, command);
+  } else {
+    console.log(`Building stylesheet(s) to ${output}`);
+  }
 
   // Run command
   cmd.runSync(command);


### PR DESCRIPTION
## Overview

Log the `postcss` command during build process if process was run with `--verbose`.