### PR TITLE
fix: vertically center logo that has manual height

### DIFF
--- a/src/lib/_imports/trumps/s-header.css
+++ b/src/lib/_imports/trumps/s-header.css
@@ -63,6 +63,10 @@ Styleguide Trumps.Scopes.Header
   flex-basis: 175px;
   margin-right: 15px; /* NO-R/EM: 1rem (from Bootstrap via `.navbar-brand`) */
 
+  /* To veritcally center child image that has manual height */
+  display: grid;
+  align-items: center;
+
   padding: unset;
 }
 


### PR DESCRIPTION
## Overview

Vertically center logo in header if it is short.

## Related

- replaces https://github.com/TACC/Core-CMS-Custom/pull/516
- fixes https://github.com/TACC/Core-CMS/pull/1000
- inspired by [TACC/tup-ui ad-hoc CSS](https://github.com/TACC/tup-ui/blob/1581b07/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/ad-hoc/navbar-width-horz-scrollbar.css#L17-L21)
- fixed by #551

## Changes

- added styles

## Testing

1. Add styles live.
2. Verify logo is smaller.

## UI

| before | after |
| - | - |
| <img width="960" height="530" alt="before" src="https://github.com/user-attachments/assets/5282cf22-c07c-4e95-9fa6-bd13f511ae94" /> | <img width="960" height="530" alt="after" src="https://github.com/user-attachments/assets/caf2ee29-6b24-4697-8f1d-7a227efe744d" /> |