### PR TITLE
fix: header logo sans height is too tall

### DIFF
--- a/src/lib/_imports/trumps/s-header.css
+++ b/src/lib/_imports/trumps/s-header.css
@@ -64,7 +64,7 @@ Styleguide Trumps.Scopes.Header
   margin-right: 15px; /* NO-R/EM: 1rem (from Bootstrap via `.navbar-brand`) */
 
   /* To veritcally center child image that has manual height */
-  display: grid;
+  display: flex;
   align-items: center;
 
   padding: unset;


### PR DESCRIPTION
## Overview

If a header logo is not given a height, then it will be taller than the header.

## Related
- fixes #545

## Changes

- **changes** `grid` to `flex`

## Testing & UI

https://github.com/user-attachments/assets/75f552bf-eca5-4e3d-b79a-72dab39b8b94

https://github.com/user-attachments/assets/63b281ee-5e2c-4cb2-a28c-3c2c3994cfbc
