### PR TITLE
fix: silence misleading syntax warnings for calc

### DIFF
--- a/src/.postcssrc.base.yml
+++ b/src/.postcssrc.base.yml
@@ -35,6 +35,9 @@ plugins:
         # So that if we use `initial` it remains `initial`
         # SEE: src/lib/_imports/tools/x-mailto-text-replace.css
         reduceInitial: false
+        # Silence misleading syntax warnings
+        # https://github.com/postcss/postcss-calc/issues/216#issuecomment-3680948805
+        calc: false
 
   postcss-banner:
     banner: 'no build id'


### PR DESCRIPTION
## Overview

Silence many warnings about `calc` syntax that are not a real problem.

## Related

- warnings began in #528
- local resolution for:
    - https://github.com/postcss/postcss-calc/issues/216
    - https://github.com/postcss/postcss-calc/issues/233

## Changes

- **disabled** `calc` minification

## Testing

1. `npm start`
2. No build warnings.
3. Open site.
4. Site loads.

## UI

Skipped.