### PR TITLE
fix: button height too short

### DIFF
--- a/src/lib/_imports/components/c-button.css
+++ b/src/lib/_imports/components/c-button.css
@@ -23,7 +23,7 @@
   align-items: center;
   justify-content: center;
 
-  line-height: 1; /* to make consistent vertical alignment of icons */
+  line-height: 1.5; /* to make consistent vertical alignment of icons */
   gap: 0.5ch; /* to add space between icons and text */
 
   /* To ensure identical <button> and <a> instances have same width */


### PR DESCRIPTION
## Overview

Button height too short.

## Related

- [WP-1188](https://tacc-main.atlassian.net/browse/WP-1188)

## Changes

- **changed** button line-height

## Testing & UI

https://github.com/user-attachments/assets/76452213-a36b-45c0-8f87-1bbc9bccc5f8

https://github.com/user-attachments/assets/1f947fca-fc21-4102-96bb-61373c58da51