### PR TITLE
chore: delete defunct npm test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,8 +243,6 @@ npm run build:css -- --build-id="..."
 
 All testing is done manually.
 
-Run `npm test` to build test CSS and compare output. An `Input Error: You must pass a valid list of files to parse` message is expected and does not indicate failure.
-
 
 ## Deployment
 

--- a/bin/test.js
+++ b/bin/test.js
@@ -1,9 +1,0 @@
-#!/usr/bin/env node
-
-/** Test CSS plugins via the Core-Styles API */
-
-const { buildStylesheets } = require('../src/main');
-
-buildStylesheets('src/lib/_tests/**/*!(README).css', './dist', {
-  baseMirrorDir: 'src/lib',
-});

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "prebuild:demo": "rm -rf dist/_utils && cp -r src/lib/_utils dist/_utils",
     "prestart": "npm run prebuild:demo",
     "build:demo": "fractal build",
-    "test": "bin/test.js && echo \"Test output at 'dist/_tests' (compare to test input)\"",
     "build:watch": "npm run build:css && touch src/lib/_imports/fractal.server.refresh.css",
     "watch": "npm-watch"
   },


### PR DESCRIPTION
## Overview

The test input files (`src/lib/_tests/`) were removed in 511c8705 but `bin/test.js` and the `test` script in `package.json` were left behind. They ran against an empty directory and always produced an error. Removed both. All testing is done manually.
