### PR TITLE
chore: npm update & remove fs-extra dev dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@fractality/fractality": "^1.6.3",
         "@fractality/handlebars": "^1.4.3",
         "@fractality/mandelbrot": "^1.12.3",
-        "fs-extra": "^11.3.3",
         "minimist": "^1.2.7",
         "npm-watch": "^0.13.0"
       },

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "@fractality/fractality": "^1.6.3",
     "@fractality/handlebars": "^1.4.3",
     "@fractality/mandelbrot": "^1.12.3",
-    "fs-extra": "^11.3.3",
     "minimist": "^1.2.7",
     "npm-watch": "^0.13.0"
   },


### PR DESCRIPTION
## Overview / Related

Clean up dependencies since #595.

## Related

- polish #595
- test assumption from https://github.com/sitepark/fractality/issues/438

## Changes

- deleted `fs-extra` as dev dep
- synced lockfile via `npm update`

## Testing

1. `npm ci`
2. `npm build`
3. `npm start`
4. No errors.
5. UI works.

## UI

Skipped.