### PR TITLE
chore: simplify release process

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -34,16 +34,5 @@ Only appointed team members may publish releases.
     `npm publish --access public`\
     <sub>Project build will automatically occur before publish.</sub>
 1. Create release and tag on GitHub.
-1. Fetch the latest tags.\
-    `git fetch --tags`
-1. Check whether tag is annotated.\
-    `git describe --always`\
-    (expect `vN.N.N` i.e. the version tag)
-1. **If** tag is **not** annotated, **then**:
-    1. Annotate Github's tag:\
-        `bin/annotate-tag.sh vN.N.N`\
-        (where `N.N.N` is the version tag)
-    1. Overwrite remote tag with annotated one:\
-        `git push --tags --force`
 
 </details>

--- a/bin/build.js
+++ b/bin/build.js
@@ -4,9 +4,10 @@
 
 const { buildStylesheets } = require('../src/main');
 const mininmist = require('minimist');
+const gitDescribe = require('./git-describe');
 
 const ARGS = mininmist( process.argv.slice( 2 ) );
-const BUILD_ID = ARGS['build-id'] || '';
+const BUILD_ID = ARGS['build-id'] || gitDescribe() || '';
 
 /* Theme: (default) */
 buildStylesheets('src/lib/_imports/**/*!(fractality.server.refresh).css', './dist', {

--- a/bin/git-describe.js
+++ b/bin/git-describe.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+/** Get tag-based description from Git */
+function gitDescribe() {
+  const { execSync } = require('child_process');
+
+  try {
+    return execSync(
+      'git describe --tags 2>/dev/null || git rev-parse --short HEAD',
+      { encoding: 'utf8' }
+    ).trim();
+  } catch (error) {
+    console.error('Error running `git describe`:', error.message);
+    return undefined;
+  }
+}
+
+module.exports = gitDescribe;

--- a/bin/release-publish.sh
+++ b/bin/release-publish.sh
@@ -50,23 +50,12 @@ else
 fi
 
 # Create GitHub release
-echo "Please create a release on GitHub now."
-echo "Visit: https://github.com/TACC/Core-Styles/releases/new"
-read -p "Press Enter once you've created the release..."
-
-# Fetch and check tags
-echo "Fetching tags..."
-git fetch --tags
-
-echo "Checking if tag is annotated..."
-if git describe --exact-match "$version_tag" >/dev/null 2>&1; then
-    echo "Tag $version_tag is already annotated"
+if command_exists gh; then
+    echo "Creating GitHub release..."
+    gh release create "$version_tag" --generate-notes
 else
-    echo "Tag $version_tag is not annotated, annotating..."
-    ./bin/annotate-tag.sh "$version_tag"
-
-    echo "Force pushing annotated tag..."
-    git push --tags --force
+    echo "gh CLI not found. Please create a release manually:"
+    echo "Visit: https://github.com/TACC/Core-Styles/releases/new?tag=${version_tag}"
 fi
 
-echo "Release process complete!" 
+echo "Release process complete!"


### PR DESCRIPTION
## Overview

Removes manual steps and annotation workarounds from the release process by adopting the Core-CMS approach to build IDs and automating the GitHub release step.

## Related

- mirrors https://github.com/TACC/Core-CMS/blob/v4.40.0-rc8/bin/git-describe.js

## Changes

- **added** `bin/git-describe.js` — use `git describe --tags` 
- **updated** `bin/build.js` — fallback to `gitDescribe()`
- **updated** `bin/release-publish.sh` — automate release as available
- **deleted** stale steps from `PUBLISHING.md`"Manual" section

## Testing

1. `npm run build:css`
2. Confirm build ID in dist CSS comment reflects current tag/SHA.
3. Dry-run `./bin/release-prepare.sh` on a test branch.
4. Confirm `./bin/release-publish.sh vX.X.X` no longer pauses for manual GitHub release creation.

## UI

Tested via https://github.com/TACC/Core-Styles/pull/656 to create https://github.com/TACC/Core-Styles/releases/tag/v2.57.3-rc1.

## Notes

`bin/annotate-tag.sh` is now dead code — safe to delete in a follow-up once the team confirms the build ID works correctly with lightweight tags.