### PR TITLE
fix: release script robustness

### DIFF
--- a/bin/git-describe.js
+++ b/bin/git-describe.js
@@ -2,17 +2,18 @@
 
 /** Get tag-based description from Git */
 function gitDescribe() {
-  const { execSync } = require('child_process');
+  const { execFileSync } = require('child_process');
 
-  try {
-    return execSync(
-      'git describe --tags 2>/dev/null || git rev-parse --short HEAD',
-      { encoding: 'utf8' }
-    ).trim();
-  } catch (error) {
-    console.error('Error running `git describe`:', error.message);
-    return undefined;
+  function runGit(args) {
+    return execFileSync('git', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    }).trim();
   }
+
+  try { return runGit(['describe', '--tags']); } catch {}
+  try { return runGit(['rev-parse', '--short', 'HEAD']); } catch {}
+  return undefined;
 }
 
 module.exports = gitDescribe;

--- a/bin/release-publish.sh
+++ b/bin/release-publish.sh
@@ -52,7 +52,10 @@ fi
 # Create GitHub release
 if command_exists gh; then
     echo "Creating GitHub release..."
-    gh release create "$version_tag" --generate-notes
+    if ! gh release create "$version_tag" --generate-notes; then
+        echo "gh failed. Please create a release manually:"
+        echo "Visit: https://github.com/TACC/Core-Styles/releases/new?tag=${version_tag}"
+    fi
 else
     echo "gh CLI not found. Please create a release manually:"
     echo "Visit: https://github.com/TACC/Core-Styles/releases/new?tag=${version_tag}"


### PR DESCRIPTION
## Overview

Addresses three Qodo review findings from #655 that flagged reliability issues in the release scripts added in that PR.

## Related

- follow-up to #655

## Changes

- **updated** `bin/git-describe.js` — replaced POSIX shell pipeline (`2>/dev/null || ...`) with two explicit `execFileSync` try/catch calls; avoids shell-dependency and silently drops expected failures (no `.git` dir, git not installed)
- **updated** `bin/release-publish.sh` — wrapped `gh release create` in `if !` guard so a `gh` failure (auth error, network, release already exists) prints the manual URL instead of aborting under `set -e`

## Testing

1. `npm run build:css` — confirm build ID in dist CSS comment reflects current tag/SHA
2. Run `./bin/release-publish.sh` with `gh` auth revoked — confirm it prints the manual URL instead of exiting with an error

## UI

```shell
% git describe --tags
v2.57.3-rc1-2-g9f3fb300
% node bin/git-describe.js
# nothin (expected) cuz the export is a function
% node -e "console.log(require('./bin/git-describe.js')())"
v2.57.3-rc1-2-g9f3fb300
```