### PR TITLE
fix(release.sh): use squash merge

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -102,7 +102,7 @@ if command_exists gh; then
         --base main \
         --head "$branch_name"
     echo "Enabling auto-merge..."
-    gh pr merge "$branch_name" --auto --merge
+    gh pr merge "$branch_name" --auto --squash
     echo "Waiting for PR to merge..."
     while [ "$(gh pr view "$branch_name" --json state --jq '.state')" != "MERGED" ]; do
         sleep 5


### PR DESCRIPTION
## Overview

`gh pr merge --merge` fails because merge commits are not allowed on this repo. Switches to `--squash`.

## Related

- follow-up to #658

## Changes

- **fixed** `bin/release.sh` — `--merge` → `--squash`

## Testing

Run `./bin/release.sh` for a real or rc release and confirm the PR auto-merges.

## UI

…