### PR TITLE
chore: match release PR title and body to prior convention

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -97,8 +97,10 @@ git push origin "$branch_name"
 if command_exists gh; then
     echo "Creating PR..."
     gh pr create \
-        --title "Release/$version_tag" \
-        --body "" \
+        --title "ci: $version_tag" \
+        --body "## Overview
+
+Prepare for $version_tag release." \
         --base main \
         --head "$branch_name"
     echo "Enabling auto-merge..."


### PR DESCRIPTION
## Overview

Updates `release.sh` to title PRs `ci: vN.N.N` and body `## Overview\nPrepare for vN.N.N release.` — matching the convention used in prior release PRs like #650.

## Related

- follow-up to #658

## Changes

- **updated** `bin/release.sh` — PR title and body now match prior convention

## Testing

Run `./bin/release.sh` for a test release and confirm the PR title/body look right.

## UI

…