### PR TITLE
fix(release.sh): mark rc GitHub releases as pre-release

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -142,7 +142,11 @@ fi
 # Create GitHub release
 if command_exists gh; then
     echo "Creating GitHub release..."
-    if ! gh release create "$version_tag" --generate-notes; then
+    release_args=(--generate-notes)
+    if [[ "$version_number" =~ -rc[0-9]+$ ]]; then
+        release_args+=(--prerelease)
+    fi
+    if ! gh release create "$version_tag" "${release_args[@]}"; then
         echo "gh failed. Please create a release manually:"
         echo "Visit: https://github.com/TACC/Core-Styles/releases/new?tag=${version_tag}"
         read -rp "Press Enter once you've created the release..."


### PR DESCRIPTION
## Overview

RC GitHub releases were being created as "latest" instead of pre-release.

## Changes

- **fixed** `bin/release.sh` — adds `--prerelease` flag to `gh release create` when version matches `-rcN` pattern

## Testing

Run `./bin/release.sh` for an rc version and confirm the GitHub release is marked as pre-release.

## UI

…