### PR TITLE
fix(release.sh): remove --build-id flag; fallback stamp is sufficient

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -86,7 +86,7 @@ npm version "$version_tag" --no-git-tag-version
 
 # Build again with new version
 echo "Building with new version..."
-npm run build:css -- --build-id="$(git describe --tags)"
+npm run build:css
 
 # Commit and push
 git add .


### PR DESCRIPTION
My recent release process simplification introduced version specificity that causes new version tag on build after EVERY commit. Last PR today, methinks 😮‍💨.