### PR TITLE
fix(release.sh): strip leading v from version input

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -32,6 +32,7 @@ fi
 # Get current version and prompt for new version
 current_version=$(npm pkg get version | tr -d '"')
 read -r -p "Enter version number (current: $current_version, format: N.N.N): " version
+version="${version#v}"
 version_tag="v$version"
 version_number="$version"
 


### PR DESCRIPTION
Strips a leading `v` from the version input so typing `v2.57.3-rc5` or `2.57.3-rc5` both produce the correct `v2.57.3-rc5` tag.