### PR TITLE
fix(generic): input file field height cuts off UI

### DIFF
--- a/src/lib/_imports/elements/form.css
+++ b/src/lib/_imports/elements/form.css
@@ -61,8 +61,7 @@ textarea {
 :is(input, textarea):read-only {
   border-color: transparent;
 }
-input, select {
-  height: 1.4em;
+input:not([type="file"]), select {
   box-sizing: content-box;
 }
 

--- a/src/lib/_imports/elements/form.css
+++ b/src/lib/_imports/elements/form.css
@@ -62,6 +62,7 @@ textarea {
   border-color: transparent;
 }
 input:not([type="file"]), select {
+  height: 1.4em;
   box-sizing: content-box;
 }
 


### PR DESCRIPTION
## Overview

Height of `<input type="file">` was cut short, cutting off its native browser UI.

## Related

- mimicked by https://github.com/TACC/Core-CMS-Custom/pull/544

## Changes

- **added** selector qualifier

## Testing & UI

https://github.com/user-attachments/assets/c3dde447-c247-4734-96fc-11d2b3e4f44a