### PR TITLE
fix(o-section): background gaps on wide screens

### DIFF
--- a/src/lib/_imports/objects/o-section.css
+++ b/src/lib/_imports/objects/o-section.css
@@ -104,12 +104,13 @@
 /* Modifers: Style: Text & Background */
 
 :--o-section--style {
-  --box-shadow--fake-bkgd: 50vw 0 var(--color--bkgd),
-                          -50vw 0 var(--color--bkgd);
+  --box-shadow--fake-bkgd: 100vw 0 0 100vw var(--color--bkgd),
+                          -100vw 0 0 100vw var(--color--bkgd);
 
   color: var(--color--text);
-  background-color: var(--color--bkgd);
-  box-shadow: var(--box-shadow--fake-bkgd);
+  background-color: var(--color--bkgd); /* the real bkgd */
+  box-shadow: var(--box-shadow--fake-bkgd); /* the extended bkgd */
+  clip-path: inset(0 -100vw); /* to hide vertical overflow of extended bkgd */
 }
 /* Nested sections must not stretch to page edge */
 :--o-section--style :--o-section--style {
@@ -152,6 +153,7 @@
 
 :--o-section--style.o-section--banner + :--o-section--style {
   box-shadow: var(--box-shadow--fake-bkgd);
+  clip-path: inset(0 -100vw);
 }
 
 

--- a/src/lib/_imports/objects/o-section.css
+++ b/src/lib/_imports/objects/o-section.css
@@ -108,8 +108,8 @@
                           -100vw 0 0 100vw var(--color--bkgd);
 
   color: var(--color--text);
-  background-color: var(--color--bkgd); /* the real bkgd */
-  box-shadow: var(--box-shadow--fake-bkgd); /* the extended bkgd */
+  background-color: var(--color--bkgd);
+  box-shadow: var(--box-shadow--fake-bkgd);
   clip-path: inset(0 -100vw); /* to hide vertical overflow of extended bkgd */
 }
 /* Nested sections must not stretch to page edge */

--- a/src/lib/_imports/objects/o-section/o-section.hbs
+++ b/src/lib/_imports/objects/o-section/o-section.hbs
@@ -30,6 +30,11 @@
     <p>{{> @text-of-one-paragraph-with-actions }}</p>
     {{> @button-samples }}
 </section>
+<section class="container o-section o-section--style-accent">
+    <h2>Accent Section (with <code>.container</code>)</h2>
+    <p>Combining <code>.container</code> directly on an <code>.o-section</code> caps its own width at very wide viewports (&gt;1920px), which can expose gaps in the fake background beyond ~3160px (or try zooming out).</p>
+    {{> @button-samples }}
+</section>
 <section class="o-section o-section--style-muted">
     <h2>Muted Section</h2>
     <p>{{> @text-of-one-paragraph-with-actions }}</p>


### PR DESCRIPTION
## Overview

Fixes gray background gaps (on wide screens) beside sections that use a "fake" full-width background (`o-section--style`).

## Related

- similar to [TACC/Core-CMS#1218](https://github.com/TACC/Core-CMS/pull/1218)

## Changes

- **changed** `/src/**/o-section.css`

## Testing

1. `npm start`
2. View a demo with a styled `container o-section` at a wide viewport (e.g. 1920px).
3. Verify the fake full-width background has no gaps.


| before | after |
| - | - |
| <img width="900" height="535" alt="before" src="https://github.com/user-attachments/assets/c396a277-db7b-42a9-831d-5ca306238bbe" /> | <img width="900" height="535" alt="after" src="https://github.com/user-attachments/assets/88b85d2e-c6c2-48fd-b100-5b85b3332b51" /> |
