### PR TITLE
docs(o-section): demo .container + .o-section combo

### DIFF
--- a/src/lib/_imports/objects/o-section/o-section.hbs
+++ b/src/lib/_imports/objects/o-section/o-section.hbs
@@ -30,6 +30,11 @@
     <p>{{> @text-of-one-paragraph-with-actions }}</p>
     {{> @button-samples }}
 </section>
+<section class="container o-section o-section--style-accent">
+    <h2>Accent Section (with <code>.container</code>)</h2>
+    <p>Combining <code>.container</code> directly on an <code>.o-section</code> caps its own width at very wide viewports (&gt;1920px), which can expose gaps in the fake background beyond ~3160px (or try zooming out).</p>
+    {{> @button-samples }}
+</section>
 <section class="o-section o-section--style-muted">
     <h2>Muted Section</h2>
     <p>{{> @text-of-one-paragraph-with-actions }}</p>


### PR DESCRIPTION
## Overview

Adds a demo section that combines `.container` directly on an `.o-section`, to make the wide-viewport fake-background gap bug reproducible in this repo's own component preview.

## Related

- to show bug for fix of https://github.com/TACC/Core-Styles/pull/675

## Changes

- **added** an "Accent Section (with `.container`)" demo variant combining `.container` and `.o-section` classes on the same element

## Testing

1. `npm start`
2. Visit the `o-section` component preview
3. Zoom out (or use an ultra-wide viewport) past ~3160px effective width
4. Observe the gap in the fake background on the new "Accent Section (with `.container`)" demo

## UI

<img width="900" height="535" alt="before" src="https://github.com/user-attachments/assets/c396a277-db7b-42a9-831d-5ca306238bbe" />