### PR TITLE
refactor: publish to npm via GitHub Actions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,39 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write  # Required for npm OIDC trusted publishing
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Determine npm dist-tag
+        id: dist_tag
+        run: |
+          if [[ "${{ github.event.release.tag_name }}" =~ -rc[0-9]+$ ]]; then
+            echo "tag=rc" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        run: npm publish --access public --tag ${{ steps.dist_tag.outputs.tag }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,11 @@
-name: Publish to npm
+# This workflow will publish a package to NPM when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+#
+# Unlike Core-Components, this workflow does not run `npm test` (no test script
+# exists yet) or build the package (dist/ is already built and committed by
+# bin/release.sh before the release is created).
+
+name: Node.js Package
 
 on:
   release:
@@ -6,26 +13,19 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: read
-  id-token: write  # Required for npm OIDC trusted publishing
+  id-token: write  # Required for OIDC
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Ensure npm supports trusted publishing
-        run: npm install -g npm@latest
-
-      - name: Install dependencies
-        run: npm ci
-
+          package-manager-cache: false  # never use caching in release builds
+      - run: npm install
       - name: Determine npm dist-tag
         id: dist_tag
         run: |
@@ -34,6 +34,4 @@ jobs:
           else
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Publish to npm
-        run: npm publish --access public --tag ${{ steps.dist_tag.outputs.tag }}
+      - run: npm publish --tag ${{ steps.dist_tag.outputs.tag }}

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -2,11 +2,13 @@
 
 Only appointed team members may publish releases.
 
+Publishing to npm happens automatically via the [`npm-publish`](.github/workflows/npm-publish.yml) GitHub Actions workflow, which runs whenever a GitHub release is created. It authenticates to npm via [Trusted Publishing (OIDC)](https://docs.npmjs.com/trusted-publishers), so no npm token or local `npm login`/`npm publish` step is needed.
+
+<sub>One-time setup: an npm org admin must register this repo + workflow as a Trusted Publisher on the `@tacc/core-styles` package settings page on npmjs.com.</sub>
+
 ### Automated Release (Bash Scripts)
 
-1. (if not already) Login to npm via:\
-    `npm login`
-2. Run the release script:\
+1. Run the release script:\
     `./bin/release.sh`
 
 ### Manual Release Steps
@@ -14,8 +16,6 @@ Only appointed team members may publish releases.
 <details>
 <summary>Instructions</summary>
 
-1. (one time) Login to npm via:\
-    `npm login`
 1. Create new branch for version bump.
 1. Verify build is up-to-date:\
     `npm run build:css`\
@@ -26,9 +26,7 @@ Only appointed team members may publish releases.
 1. Build with new version:\
     `npm run build:css`
 1. Commit, push, PR, review, merge.
-1. Publish to NPM via:\
-    `npm publish --access public`\
-    <sub>Project build will automatically occur before publish.</sub>
-1. Create release and tag on GitHub.
+1. Create release and tag on GitHub.\
+    <sub>This triggers the `npm-publish` GitHub Actions workflow, which publishes to npm.</sub>
 
 </details>

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -2,16 +2,12 @@
 
 Only appointed team members may publish releases.
 
-Publishing to npm happens automatically via the [`npm-publish`](.github/workflows/npm-publish.yml) GitHub Actions workflow, which runs whenever a GitHub release is created. It authenticates to npm via [Trusted Publishing (OIDC)](https://docs.npmjs.com/trusted-publishers), so no npm token or local `npm login`/`npm publish` step is needed.
-
-<sub>One-time setup: an npm org admin must register this repo + workflow as a Trusted Publisher on the `@tacc/core-styles` package settings page on npmjs.com.</sub>
-
-### Automated Release (Bash Scripts)
+### Automated Release
 
 1. Run the release script:\
     `./bin/release.sh`
 
-### Manual Release Steps
+### Manual Release
 
 <details>
 <summary>Instructions</summary>

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -14,15 +14,6 @@ if ! command_exists git; then
     exit 1
 fi
 
-# Check npm login status
-if ! npm whoami >/dev/null 2>&1; then
-    echo "Error: You are not logged in to npm."
-    echo -e "Please login first with:\n    npm login"
-    echo -e "\nNote: When running npm login, you'll be prompted to visit a URL in your browser."
-    echo "Make sure you're already logged into npmjs.com in your browser before starting."
-    exit 1
-fi
-
 # Ensure working directory is clean
 if [ -n "$(git status --porcelain)" ]; then
     echo "Error: Working directory has unexpected changes. Please commit or stash changes."
@@ -60,8 +51,7 @@ echo "1. Build CSS"
 echo "2. Update version"
 echo "3. Create release commit"
 echo "4. Open a PR and auto-merge it"
-echo "5. Publish to npm"
-echo "6. Create GitHub release"
+echo "5. Create a GitHub release (which triggers npm publish via GitHub Actions)"
 if ! confirm "Do you want to proceed?"; then
     echo "Release cancelled."
     exit 0
@@ -120,26 +110,6 @@ fi
 git checkout main
 git pull origin main
 
-# Publish to npm
-if npm view "@tacc/core-styles@${version_number}" >/dev/null 2>&1; then
-    echo "Version ${version_number} is already published to npm."
-    if ! confirm "Skip npm publish step?"; then
-        echo "Aborting to avoid version conflict."
-        exit 1
-    fi
-else
-    npm_publish_args=(--access public)
-
-    if [[ "$version_number" =~ -rc[0-9]+$ ]]; then
-        npm_publish_args+=(--tag rc)
-        echo "Publishing ${version_number} (release candidate) to npm (with 'rc' tag)..."
-    else
-        echo "Publishing ${version_number} to npm..."
-    fi
-
-    npm publish "${npm_publish_args[@]}"
-fi
-
 # Create GitHub release
 if command_exists gh; then
     echo "Creating GitHub release..."
@@ -158,4 +128,4 @@ else
     read -rp "Press Enter once you've created the release..."
 fi
 
-echo "Release complete!"
+echo "Release complete! npm publish will run via GitHub Actions now that the release was created."

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -128,4 +128,5 @@ else
     read -rp "Press Enter once you've created the release..."
 fi
 
-echo "Release complete! npm publish will run via GitHub Actions now that the release was created."
+echo "GitHub release complete!"
+echo "NPM release should have been triggered via GitHub Actions."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@tacc/core-styles",
   "version": "2.57.4",
+  "publishConfig": {
+    "access": "public"
+  },
   "license": "MIT",
   "author": "TACC COA CMD <coa-cmd@tacc.utexas.edu>",
   "contributors": [


### PR DESCRIPTION
## Overview

Moves `npm publish` out of `bin/release.sh` in to new GitHub Actions workflow that runs when a GitHub release is created (authenticating via npm Trusted Publishing (OIDC) instead of a long-lived npm token).

> [!CAUTION]
> Untested!

## Related

- [TACC/Core-Components:`/.../npm-publish.yml`](https://github.com/TACC/Core-Components/blob/v0.0.5/.github/workflows/npm-publish.yml)

## Changes

- **added** workflow for `npm publish`
- **changed** `release` script (no `npm` actions)
- **updated** `PUBLISHING.md`

## Testing

1. `bash -n bin/release.sh` — syntax check passes
2. Publish a test release `...-rc…`.
3. Verify release succeeds.
4. Verify process performs all things previous release process does.

## Notes

> [!TIP]
> Prerequisite (manual, on npmjs.com) of registering `TACC/Core-Styles` and `npm-publish.yml` as a Trusted Publisher for `@tacc/core-styles` is **completed**.