### PR TITLE
feat(elements): add cms.v2-bridge-for-v3-users stylesheet + doc

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -62,6 +62,13 @@ Load **first** `core-styles.base.css` **then** any one of these relevant project
 
 <sup>Replace `______` with `cms`, `docs`, `portal`, etc.</sup>
 
+> [!TIP]
+> To keep old `<h2>` styles in a `cms.css`-base project on v3, **append**
+>
+> ```css
+> @import url("https://cdn.jsdelivr.net/npm/@tacc/core-styles@v3/dist/core-styles.cms.v2-bridge-for-v3-users.css") layer(base);
+> ```
+
 ### 2. Project
 
 Load global stylesheet(s) specific to your project.


### PR DESCRIPTION
## Overview

Adds a HOWTO note for `core-styles.cms.v2-bridge-for-v3-users.css` — for v3 sites whose CMS content still uses `<h2>` as an intro paragraph (instead of `<p class="h2">`) and needs that look restored after upgrading.

## Related

- v2-side equivalent: https://github.com/TACC/Core-Styles/pull/683

## Changes

- **added** a HOWTO.md tip under "1. Base" showing how to load `core-styles.cms.v2-bridge-for-v3-users.css`

## Notes

The stylesheet itself is intentionally not added here — it'll arrive via the merge of `main` after #683 lands, rather than being hand-ported to this branch's `.postcss` convention ahead of that.

No CHANGELOG entry and no version bump, per current release-via-GitHub-Releases process.