### PR TITLE
docs(agents): Changes bullets leave detail to the diff, not prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ This is a **Node/PostCSS** styles project. Build outputs are generated artifacts
   - Be concise: plain language, simple sentences, present lists as bullets not prose.
   - When summarizing changeset, say what changed and (only if it matters) why, never how.
   - If listing a file change, then only describe change at a high level.
-  - In "Changes" section, group into as few bullets as the logical changes require (never one per file) and default to zero explanation per bullet (e.g. `**added** logos`).
+  - In "Changes" section, group into as few bullets as the logical changes require (never one per file) and default to zero explanation per bullet (e.g. `**added** logos`). Leave the detail for the code diff itself — a bullet is not the place to restate what the diff already shows.
   - In "Overview" section, match the template's example length (1 sentence), not its stated max (1–3).
   - When updating, first re-read the current description, because it may have been edited.
   - In "Related" section, links to PRs should instead just be raw URLs (because GitHub will auto-create rich links).


### PR DESCRIPTION
## Overview

Clarify AGENTS.md's existing "zero explanation per bullet" rule for PR "Changes" sections, since it wasn't preventing verbose bullets in practice.

## Changes

- **changed** AGENTS.md's "Changes" section rule to explicitly say detail belongs in the diff, not the bullet