### PR TITLE
refactor(tools): make v3's heading redesign the live heading-N mixins

### DIFF
--- a/src/lib/_imports/tacc/tools/x-headings--cms.postcss
+++ b/src/lib/_imports/tacc/tools/x-headings--cms.postcss
@@ -1,5 +1,3 @@
-@import url("./x-lead.postcss");
-
 @define-mixin heading-1 {
     font-size: var(--global-font-size--xx-large);
     font-weight: var(--black);
@@ -8,11 +6,9 @@
     text-transform: uppercase;
 }
 
+/* v3: no longer carries the lead-paragraph look (SEE trumps/s-lead.postcss) */
 @define-mixin heading-2 {
-    @mixin x-lead;
-}
-
-@define-mixin heading-3 {
+    color: inherit;
     font-size: var(--global-font-size--large);
     font-weight: var(--black);
 
@@ -21,9 +17,19 @@
 }
 
 /* WARNING: No design available; these are just developer guesswork */
-@define-mixin heading-4 {
+/* margin-top/margin-bottom mimic Bootstrap 4/5 Reboot's heading margin (their only source of one) so this matches what h3 actually renders as today, not a raw un-authored browser default. */
+@define-mixin heading-3 {
     font-size: var(--global-font-size--medium);
     font-weight: var(--bold);
+
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+}
+
+/* Distinct from heading-3 (bold) without exceeding v3's design voice: same size as body, just medium weight. */
+@define-mixin heading-4 {
+    font-size: inherit;
+    font-weight: var(--medium);
 }
 
 /* To deter use of "smaller" headings by making them match body font */
@@ -37,31 +43,12 @@
 }
 
 /*
-v3's heading redesign: <h2> stops carrying the lead-paragraph look (SEE
-trumps/s-lead.postcss); every level below h1 shifts down to the next
-level's current look. Named per-level so h1-h6 and .h1-.h6 (SEE
-elements/headings--cms.postcss) share one definition instead of
-duplicating it.
+Named per-level so h1-h6 and .h1-.h6 (SEE elements/headings--cms.postcss)
+share one definition instead of duplicating it.
 */
-@define-mixin heading-1--cms {
-    @mixin heading-1;
-}
-@define-mixin heading-2--cms {
-    @mixin heading-3;
-    color: inherit;
-}
-@define-mixin heading-3--cms {
-    @mixin heading-4;
-    margin-top: 0;
-    margin-bottom: 0.5rem;
-}
-@define-mixin heading-4--cms {
-    font-size: inherit;
-    font-weight: var(--medium);
-}
-@define-mixin heading-5--cms {
-    @mixin heading-6;
-}
-@define-mixin heading-6--cms {
-    @mixin heading-6;
-}
+@define-mixin heading-1--cms { @mixin heading-1; }
+@define-mixin heading-2--cms { @mixin heading-2; }
+@define-mixin heading-3--cms { @mixin heading-3; }
+@define-mixin heading-4--cms { @mixin heading-4; }
+@define-mixin heading-5--cms { @mixin heading-5; }
+@define-mixin heading-6--cms { @mixin heading-6; }

--- a/src/lib/_imports/tacc/tools/x-headings--cms.postcss
+++ b/src/lib/_imports/tacc/tools/x-headings--cms.postcss
@@ -6,9 +6,7 @@
     text-transform: uppercase;
 }
 
-/* Explicitly inherits color; does not use the accent color from trumps/s-lead.postcss's x-lead mixin. */
 @define-mixin heading-2 {
-    color: inherit;
     font-size: var(--global-font-size--large);
     font-weight: var(--black);
 
@@ -17,7 +15,6 @@
 }
 
 /* WARNING: No design available; these are just developer guesswork */
-/* margin-top/margin-bottom mimic Bootstrap 4/5 Reboot's heading margin (their only source of one) so this matches what h3 actually renders as today, not a raw un-authored browser default. */
 @define-mixin heading-3 {
     font-size: var(--global-font-size--medium);
     font-weight: var(--bold);
@@ -25,8 +22,6 @@
     margin-top: 0;
     margin-bottom: 0.5rem;
 }
-
-/* Distinct from heading-3 (bold) without exceeding v3's design voice: same size as body, just medium weight. */
 @define-mixin heading-4 {
     font-size: inherit;
     font-weight: var(--medium);
@@ -42,10 +37,6 @@
     font-weight: var(--normal);
 }
 
-/*
-Named per-level so h1-h6 and .h1-.h6 (SEE elements/headings--cms.postcss)
-share one definition instead of duplicating it.
-*/
 @define-mixin heading-1--cms { @mixin heading-1; }
 @define-mixin heading-2--cms { @mixin heading-2; }
 @define-mixin heading-3--cms { @mixin heading-3; }

--- a/src/lib/_imports/tacc/tools/x-headings--cms.postcss
+++ b/src/lib/_imports/tacc/tools/x-headings--cms.postcss
@@ -6,7 +6,7 @@
     text-transform: uppercase;
 }
 
-/* v3: no longer carries the lead-paragraph look (SEE trumps/s-lead.postcss) */
+/* Explicitly inherits color; does not use the accent color from trumps/s-lead.postcss's x-lead mixin. */
 @define-mixin heading-2 {
     color: inherit;
     font-size: var(--global-font-size--large);

--- a/src/lib/_imports/tacc/tools/x-headings.cms.v2.postcss
+++ b/src/lib/_imports/tacc/tools/x-headings.cms.v2.postcss
@@ -3,9 +3,9 @@ Frozen aliases for v2's heading-N mixins, for use by files that must keep
 rendering v2's heading appearance regardless of how the live heading-N
 mixins (in x-headings--cms.postcss) look in later major versions.
 
-Core-Styles v3 changed the live heading-N mixins (SEE PR #693); these
-`--v2` mixins hardcode v2's original per-level values directly so they
-stay correct regardless of future changes to the live mixins.
+These `--v2` mixins hardcode v2's original per-level values directly,
+decoupled from the live heading-N mixins, so they stay correct no matter
+how those mixins change in the future.
 */
 
 @import url("./x-headings.postcss");

--- a/src/lib/_imports/tacc/tools/x-headings.cms.v2.postcss
+++ b/src/lib/_imports/tacc/tools/x-headings.cms.v2.postcss
@@ -1,22 +1,44 @@
 /*
 Frozen aliases for v2's heading-N mixins, for use by files that must keep
 rendering v2's heading appearance regardless of how the live heading-N
-mixins (in x-headings--cms.css) change in later major versions.
+mixins (in x-headings--cms.postcss) look in later major versions.
 
-Until Core-Styles v3 actually changes those mixins, this file is a thin
-proxy — these `--v2` mixins are identical to the live ones. Once v3 changes
-them, this file must stop proxying and hardcode v2's current values
-directly, or every site relying on `--v2` mixins for old content will
-silently start rendering v3's new look instead.
+Core-Styles v3 changed the live heading-N mixins (SEE PR #693); these
+`--v2` mixins hardcode v2's original per-level values directly so they
+stay correct regardless of future changes to the live mixins.
 */
 
 @import url("./x-headings.postcss");
-@import url("./x-headings--cms.postcss");
+@import url("./x-lead.postcss");
 
 @define-mixin heading--v2 { @mixin heading; }
-@define-mixin heading-1--v2 { @mixin heading-1; }
-@define-mixin heading-2--v2 { @mixin heading-2; }
-@define-mixin heading-3--v2 { @mixin heading-3; }
-@define-mixin heading-4--v2 { @mixin heading-4; }
-@define-mixin heading-5--v2 { @mixin heading-5; }
-@define-mixin heading-6--v2 { @mixin heading-6; }
+
+@define-mixin heading-1--v2 {
+    font-size: var(--global-font-size--xx-large);
+    font-weight: var(--black);
+
+    margin-bottom: 40px;
+    text-transform: uppercase;
+}
+@define-mixin heading-2--v2 {
+    @mixin x-lead;
+}
+@define-mixin heading-3--v2 {
+    font-size: var(--global-font-size--large);
+    font-weight: var(--black);
+
+    margin-top: 0;
+    margin-bottom: 20px;
+}
+@define-mixin heading-4--v2 {
+    font-size: var(--global-font-size--medium);
+    font-weight: var(--bold);
+}
+@define-mixin heading-5--v2 {
+    font-size: inherit;
+    font-weight: var(--normal);
+}
+@define-mixin heading-6--v2 {
+    font-size: inherit;
+    font-weight: var(--normal);
+}

--- a/src/lib/_imports/tacc/tools/x-headings.cms.v2.postcss
+++ b/src/lib/_imports/tacc/tools/x-headings.cms.v2.postcss
@@ -1,11 +1,7 @@
 /*
-Frozen aliases for v2's heading-N mixins, for use by files that must keep
-rendering v2's heading appearance regardless of how the live heading-N
-mixins (in x-headings--cms.postcss) look in later major versions.
+Frozen aliases for v2's heading-N mixins, for use by files that must keep rendering v2's heading appearance regardless of how the live heading-N mixins (in x-headings--cms.postcss) look in later major versions.
 
-These `--v2` mixins hardcode v2's original per-level values directly,
-decoupled from the live heading-N mixins, so they stay correct no matter
-how those mixins change in the future.
+These `--v2` mixins hardcode v2's original per-level values directly, decoupled from the live heading-N mixins, so they stay correct no matter how those mixins change in the future.
 */
 
 @import url("./x-headings.postcss");


### PR DESCRIPTION
## Overview

Hardcodes `heading-N--v2`'s values instead of proxying the live `heading-N` mixins.

## Related

- https://github.com/TACC/Core-Styles/pull/693

## Changes

- **changed** `heading-2`/`heading-3`/`heading-4` in `x-headings--cms.postcss` to hold v3's redesigned values directly
- **hardcoded** `heading-N--v2` in `x-headings.cms.v2.postcss` with v2's original per-level values

## Testing

1. `npm install`
2. `npm run build:css`
3. `npm start`
4. Open `/components/detail/headings--cms`
5. Compare against its pre-PR state (no visual change expected)
6. Open `/components/detail/headings--cms-v2`
7. Compare against its pre-PR state (no visual change expected — that's the whole point of hardcoding)