### PR TITLE
docs(agents): tighten PR-description brevity rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,10 +39,14 @@ This is a **Node/PostCSS** styles project. Build outputs are generated artifacts
 - **Title:** `.gitmessage` (fallback: `~/.gitmessage`)
 - **Description:** `.github/PULL_REQUEST_TEMPLATE.md` (fallback: `~/.github/PULL_REQUEST_TEMPLATE.md`)
   - Be concise: plain language, simple sentences, present lists as bullets not prose.
-  - When summarizing changeset, say what changed and (only if it matters) why, never how.
+  - When summarizing changeset, say what changed and (only if omitting it would leave a reviewer confused or suspicious) why, never how.
   - If listing a file change, then only describe change at a high level.
   - In "Changes" section, group into as few bullets as the logical changes require (never one per file) and default to zero explanation per bullet (e.g. `**added** logos`). Leave the detail for the code diff itself — a bullet is not the place to restate what the diff already shows.
-  - In "Overview" section, match the template's example length (1 sentence), not its stated max (1–3).
+  - Name files/identifiers by their bare name (`x-button.css`), not their full repo path, unless the bare name is ambiguous.
+  - Describe even the "what" at the highest level that's still meaningful — prefer a general noun ("shared rules") to an enumeration of the specifics behind it ("the padding/min-width/max-width block"); the diff has the specifics.
+  - When several similarly-patterned names are affected the same way (e.g. a rename applied to 3 things), give one example plus `…` instead of listing all of them.
+  - In "Overview" section, match the template's example length (1 sentence) and density — not just its stated max (1–3), and not a single sentence stitched together from several clauses.
+  - In "Testing" section, one action per numbered step, matching the template's own example exactly — don't combine "do X, then do Y" into one step. Prefer a step that compares directly against a running reference (e.g. production) over one that re-narrates internal verification work already done elsewhere in the description.
   - When updating, first re-read the current description, because it may have been edited.
   - In "Related" section, links to PRs should instead just be raw URLs (because GitHub will auto-create rich links).
   - If responding to a PR comment as the user instead of a bot, then quote and sign your entire reply.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,15 +38,19 @@ This is a **Node/PostCSS** styles project. Build outputs are generated artifacts
 
 - **Title:** `.gitmessage` (fallback: `~/.gitmessage`)
 - **Description:** `.github/PULL_REQUEST_TEMPLATE.md` (fallback: `~/.github/PULL_REQUEST_TEMPLATE.md`)
-  - Be concise: plain language, simple sentences, present lists as bullets not prose.
-  - When summarizing changeset, say what changed and (only if omitting it would leave a reviewer confused or suspicious) why, never how.
-  - If listing a file change, then only describe change at a high level.
-  - In "Changes" section, group into as few bullets as the logical changes require (never one per file) and default to zero explanation per bullet (e.g. `**added** logos`). Leave the detail for the code diff itself — a bullet is not the place to restate what the diff already shows.
-  - Name files/identifiers by their bare name (`x-button.css`), not their full repo path, unless the bare name is ambiguous.
-  - Describe even the "what" at the highest level that's still meaningful — prefer a general noun ("shared rules") to an enumeration of the specifics behind it ("the padding/min-width/max-width block"); the diff has the specifics.
-  - When several similarly-patterned names are affected the same way (e.g. a rename applied to 3 things), give one example plus `…` instead of listing all of them.
+  - In general:
+    - When updating, first re-read the current description, because it may have been edited.
+    - Be concise: plain language, simple sentences, present lists as bullets not prose.
   - In "Overview" section, match the template's example length (1 sentence) and density — not just its stated max (1–3), and not a single sentence stitched together from several clauses.
-  - In "Testing" section, one action per numbered step, matching the template's own example exactly — don't combine "do X, then do Y" into one step. Prefer a step that compares directly against a running reference (e.g. production) over one that re-narrates internal verification work already done elsewhere in the description.
-  - When updating, first re-read the current description, because it may have been edited.
+    - Say what changed and (only if omitting it would leave a reviewer confused or suspicious) why, never how.
   - In "Related" section, links to PRs should instead just be raw URLs (because GitHub will auto-create rich links).
+  - In "Changes" section:
+    - Group changes into as few bullets as the logical changes require (never one per file)
+    - Default to zero explanation per bullet (e.g. `**added** logos`). Leave the detail for the code diff itself — a bullet is not the place to restate what the diff already shows.
+    - Name files/identifiers by their bare name (`x-button.css`), not full path, unless the bare name is ambiguous.
+    - Describe even the "what" at the highest level that's still meaningful — prefer a general noun ("shared rules") to an enumeration of the specifics behind it ("the such-and-such code block").
+    - When several similarly-patterned names are affected the same way (e.g. a rename applied to 3 things), give one example plus `…` instead of listing all of them.
+  - In "Testing" section:
+    - One action per numbered step.
+    - Prefer a step that compares directly against a running reference (e.g. production).
   - If responding to a PR comment as the user instead of a bot, then quote and sign your entire reply.


### PR DESCRIPTION
## Overview

Tightens `AGENTS.md`'s PR-description brevity rules, based on real edits made to #691's description.

## Related

n/a

## Changes

- **tightened** PR-description rules in `AGENTS.md`

## Testing

1. Read the diff against the rest of the document's style (terse bullet, bold key term, one example each)
2. Confirm each new/changed bullet still reads as a rule, not an explanation of a rule

## UI

n/a

## Notes

- Prompted by manual edits to https://github.com/TACC/Core-Styles/pull/691's description — that PR is the before/after this rule change is meant to produce going forward.
