### PR TITLE
docs(agents): document PR review comment conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,9 @@ This is a **Node/PostCSS** styles project. Build outputs are generated artifacts
   - In general:
     - When updating, first re-read the current description, because it may have been edited.
     - Be concise: plain language, simple sentences, present lists as bullets not prose.
+    - If responding to a PR comment as the user instead of a bot, then quote and sign your entire reply.
+    - Explanatory rationale specific to this PR's decisions belong in [review comments](#review-comments), not description.
+    - Code comments are only for durable, non-obvious facts for future readers regardless of PR history.
   - In "Overview" section, match the template's example length (1 sentence) and density — not just its stated max (1–3), and not a single sentence stitched together from several clauses.
     - Say what changed and (only if omitting it would leave a reviewer confused or suspicious) why, never how.
   - In "Related" section, links to PRs should instead just be raw URLs (because GitHub will auto-create rich links).
@@ -53,9 +56,6 @@ This is a **Node/PostCSS** styles project. Build outputs are generated artifacts
   - In "Testing" section:
     - One action per numbered step.
     - Prefer a step that compares directly against a running reference (e.g. production).
-  - If responding to a PR comment as the user instead of a bot, then quote and sign your entire reply.
-  - Explanatory rationale specific to this PR's decisions belong in PR comments, not description.
-  - Code comments are only for durable, non-obvious facts for future readers regardless of PR history.
 
 ### Review Comments
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,10 @@ This is a **Node/PostCSS** styles project. Build outputs are generated artifacts
   - When updating, first re-read the current description, because it may have been edited.
   - In "Related" section, links to PRs should instead just be raw URLs (because GitHub will auto-create rich links).
   - If responding to a PR comment as the user instead of a bot, then quote and sign your entire reply.
+  - Explanatory rationale specific to this PR's decisions belong in PR comments, not description.
+  - Code comments are only for durable, non-obvious facts for future readers regardless of PR history.
+
+### Review Comments
+
+- Group it into one self-review with inline comments.
+- Prefix each such comment with **Explanation:**, **Question:**, or **Suggestion:**.


### PR DESCRIPTION
## Overview

Documents that PR-specific rationale belongs in PR review comments, not code comments or the description.

## Changes

- **added** two bullets under Pull Requests clarifying where PR-specific rationale belongs vs. durable code comments
- **added** a "Review Comments" subsection: group such comments into one self-review, prefixed `**Explanation:**`, `**Question:**`, or `**Suggestion:**`

## Testing

1. Read `AGENTS.md`