### PR TITLE
feat: add Docker Compose dev workflow (make start)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,9 @@ This is a **Node/PostCSS** styles project. Build outputs are generated artifacts
 
 ### Build
 
-- If local `npm` is unavailable, use containerized Node:
+- For persistent dev environment (build watcher + demo server), run `make start` (Docker Compose; see `docker-compose.yml`). Safe to run from any git worktree — Compose namespaces containers per directory. To run a second instance from another worktree at the same time, override the ports first: `PORT=3010 make start`.
+
+- For throwaway build without installing Node locally:
   ```sh
   docker run --rm -v "$(pwd):/code" -w /code node:20 sh -lc "npm ci && npm run build:css"
   ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:20
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends rsync \
+    && rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: start stop restart logs
+
+start:
+	docker compose up
+
+stop:
+	docker compose down
+
+restart:
+	docker compose down
+	docker compose up
+
+logs:
+	docker compose logs -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  core-styles:
+    image: node:20
+    working_dir: /code
+    volumes:
+      - .:/code
+      - node_modules:/code/node_modules
+    ports:
+      - "${PORT:-3000}:3000"
+      - "${PORT_BROWSERSYNC:-3001}:3001"
+      - "${PORT_BROWSERSYNC_UI:-3002}:3002"
+    command: sh -c "npm install && (npm run watch &) && npm start"
+    stdin_open: true
+    tty: true
+
+volumes:
+  node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   core-styles:
-    image: node:20
+    build: .
     working_dir: /code
     volumes:
       - .:/code


### PR DESCRIPTION
## Overview

Adds a Docker Compose dev workflow (`make start`) that's safe to run from any git worktree.

## Changes

- **added** `docker-compose.yml` and `Makefile` for a containerized install + watch + demo-server workflow
- **updated** `AGENTS.md` to document `make start` as the preferred persistent dev environment

## Testing

1. `make start`
2. Open http://localhost:3000
3. From a second worktree, run `PORT=3010 make start`
4. Open http://localhost:3010 (both instances serve independently)

## Notes

Host ports are shared by default across worktrees (Fractal's demo server always expects 3000); running two instances at once needs the `PORT` override shown above.