### PR TITLE
refactor(tools): collapse heading-N into heading-N--cms/--docs

### DIFF
--- a/src/lib/_imports/tacc/tools/x-headings--cms.postcss
+++ b/src/lib/_imports/tacc/tools/x-headings--cms.postcss
@@ -1,4 +1,4 @@
-@define-mixin heading-1 {
+@define-mixin heading-1--cms {
     font-size: var(--global-font-size--xx-large);
     font-weight: var(--black);
 
@@ -6,7 +6,7 @@
     text-transform: uppercase;
 }
 
-@define-mixin heading-2 {
+@define-mixin heading-2--cms {
     font-size: var(--global-font-size--large);
     font-weight: var(--black);
 
@@ -15,31 +15,24 @@
 }
 
 /* WARNING: No design available; these are just developer guesswork */
-@define-mixin heading-3 {
+@define-mixin heading-3--cms {
     font-size: var(--global-font-size--medium);
     font-weight: var(--bold);
 
     margin-top: 0;
     margin-bottom: 0.5rem;
 }
-@define-mixin heading-4 {
+@define-mixin heading-4--cms {
     font-size: inherit;
     font-weight: var(--medium);
 }
 
 /* To deter use of "smaller" headings by making them match body font */
-@define-mixin heading-5 {
+@define-mixin heading-5--cms {
     font-size: inherit;
     font-weight: var(--normal);
 }
-@define-mixin heading-6 {
+@define-mixin heading-6--cms {
     font-size: inherit;
     font-weight: var(--normal);
 }
-
-@define-mixin heading-1--cms { @mixin heading-1; }
-@define-mixin heading-2--cms { @mixin heading-2; }
-@define-mixin heading-3--cms { @mixin heading-3; }
-@define-mixin heading-4--cms { @mixin heading-4; }
-@define-mixin heading-5--cms { @mixin heading-5; }
-@define-mixin heading-6--cms { @mixin heading-6; }

--- a/src/lib/_imports/tacc/tools/x-headings--docs.postcss
+++ b/src/lib/_imports/tacc/tools/x-headings--docs.postcss
@@ -1,39 +1,32 @@
-@define-mixin heading-1 {
+@define-mixin heading-1--docs {
     font-size: var(--global-font-size--xxx-large);
     font-weight: var(--black);
 
     text-transform: uppercase; /* mimics headings--cms.css */
 }
 
-@define-mixin heading-2 {
+@define-mixin heading-2--docs {
     font-size: var(--global-font-size--xx-large);
     font-weight: var(--bold);
 }
 
-@define-mixin heading-3 {
+@define-mixin heading-3--docs {
     font-size: var(--global-font-size--x-large);
     font-weight: var(--bold);
 }
 
 /* WARNING: No design available; these are just developer guesswork */
-@define-mixin heading-4 {
+@define-mixin heading-4--docs {
     font-size: var(--global-font-size--large);
     font-weight: var(--bold);
 }
 
 /* To deter use of "smaller" headings by making them match body font */
-@define-mixin heading-5 {
+@define-mixin heading-5--docs {
     font-size: inherit;
     font-weight: var(--normal);
 }
-@define-mixin heading-6 {
+@define-mixin heading-6--docs {
     font-size: inherit;
     font-weight: var(--normal);
 }
-
-@define-mixin heading-1--docs { @mixin heading-1; }
-@define-mixin heading-2--docs { @mixin heading-2; }
-@define-mixin heading-3--docs { @mixin heading-3; }
-@define-mixin heading-4--docs { @mixin heading-4; }
-@define-mixin heading-5--docs { @mixin heading-5; }
-@define-mixin heading-6--docs { @mixin heading-6; }


### PR DESCRIPTION
## Overview

Deletes the bare heading-N mixins now that nothing but their own --cms/--docs wrappers referenced them.

## Related

- https://github.com/TACC/Core-Styles/pull/702

## Changes

- **deleted** the bare `heading-N` mixins, moving their declarations directly into `heading-N--cms`/`heading-N--docs`

## Testing

1. `npm install`
2. `npm run build:css`
3. Confirmed `core-styles.cms.css` and `core-styles.docs.css` compile byte-for-byte identical to before