### PR TITLE
refactor: mixins use base name, not `x-`/`c-`/`s-` prefix (#340)

### DIFF
--- a/src/lib/_imports/bootstrap4/content/lead.css
+++ b/src/lib/_imports/bootstrap4/content/lead.css
@@ -1,5 +1,5 @@
 @import url("../../tools/x-lead.css");
 
 .lead {
-    @mixin x-lead;
+    @mixin lead;
 }

--- a/src/lib/_imports/components/bootstrap.nav-tabs.css
+++ b/src/lib/_imports/components/bootstrap.nav-tabs.css
@@ -2,11 +2,11 @@
 
 .nav-tabs,
 .tab-pane {
-  @mixin x-tabs--custom-properties;
+  @mixin tabs--custom-properties;
 }
 
 .nav-tabs {
-  @mixin x-tabs;
+  @mixin tabs;
   border-bottom: none;
 }
 ul.nav-tabs {
@@ -15,12 +15,12 @@ ul.nav-tabs {
 }
 
 .tab-pane {
-  @mixin x-tabs__content--structure;
-  @mixin x-tabs__content--skin;
+  @mixin tabs__content--structure;
+  @mixin tabs__content--skin;
 }
 .nav-tabs .nav-link {
-  @mixin x-tabs__tab--structure;
-  @mixin x-tabs__tab--skin;
+  @mixin tabs__tab--structure;
+  @mixin tabs__tab--skin;
 
   /* To overwrite Bootstrap _nav.scss border */
   border-top: none;
@@ -28,12 +28,12 @@ ul.nav-tabs {
   border-radius: 0;
 }
 .nav-tabs .nav-link:hover {
-  @mixin x-tabs__tab--hover;
+  @mixin tabs__tab--hover;
 }
 
 .nav-tabs .nav-link.active {
-  @mixin x-tabs__tab--active;
+  @mixin tabs__tab--active;
 }
 .nav-tabs .nav-link:not(.active) {
-  @mixin x-tabs__tab--not-active;
+  @mixin tabs__tab--not-active;
 }

--- a/src/lib/_imports/components/bootstrap3.breadcrumb.css
+++ b/src/lib/_imports/components/bootstrap3.breadcrumb.css
@@ -1,38 +1,38 @@
 @import url("../tools/x-breadcrumbs.css");
 
 .breadcrumb {
-  @mixin x-breadcrumbs;
+  @mixin breadcrumbs;
 
   background-color: unset;
   padding-bottom: unset;
   padding-right: unset;
 }
 .breadcrumb:where(.breadcrumb-major) {
-  @mixin x-breadcrumbs-major;
+  @mixin breadcrumbs-major;
 }
 .breadcrumb:where(:not(.breadcrumb-major)) {
   padding-top: unset;
 }
 
 .breadcrumb:where(ol, ul) {
-  @mixin x-breadcrumbs--list;
+  @mixin breadcrumbs--list;
 }
 .breadcrumb:where(ol, ul):where(.breadcrumb-major) {
-  @mixin x-breadcrumbs-major--list;
+  @mixin breadcrumbs-major--list;
 }
 
 .breadcrumb li {
-  @mixin x-breadcrumbs__list-item;
+  @mixin breadcrumbs__list-item;
 }
 .breadcrumb:where(.breadcrumb-major) li {
-  @mixin x-breadcrumbs-major__list-item;
+  @mixin breadcrumbs-major__list-item;
 }
 
 .breadcrumb > .active {
   color: inherit;
 }
 .breadcrumb li + li {
-  @mixin x-breadcrumbs__list-item--prefix-separator;
+  @mixin breadcrumbs__list-item--prefix-separator;
 }
 .breadcrumb li + li::before {
   color: inherit;

--- a/src/lib/_imports/components/c-nav.css
+++ b/src/lib/_imports/components/c-nav.css
@@ -106,7 +106,7 @@ nav[class*="c-nav--piped"] button:--c-button--as-link {
 
 /* via "after" pseduo-element */
 
-@define-mixin c-nav--piped--after {
+@define-mixin nav--piped--after {
   & > :--child-of-list,
   & > :--child-no-list {
     position: relative;
@@ -135,12 +135,12 @@ nav[class*="c-nav--piped"] button:--c-button--as-link {
   }
 }
 .c-nav--piped--after {
-  @mixin c-nav--piped--after;
+  @mixin nav--piped--after;
 }
 
 /* via "before" pseduo-element */
 
-@define-mixin c-nav--piped--before {
+@define-mixin nav--piped--before {
   & > :--child-of-list,
   & > :--child-no-list {
     position: relative;
@@ -169,11 +169,11 @@ nav[class*="c-nav--piped"] button:--c-button--as-link {
   }
 }
 .c-nav--piped--before {
-  @mixin c-nav--piped--before;
+  @mixin nav--piped--before;
 }
 /* default */
 nav.c-nav--piped:not([class*="c-nav--piped--"]) {
-  @mixin c-nav--piped--after;
+  @mixin nav--piped--after;
 }
 
 

--- a/src/lib/_imports/components/pymdownx--tabbed.css
+++ b/src/lib/_imports/components/pymdownx--tabbed.css
@@ -1,42 +1,42 @@
 @import url("../tools/x-tabs.css");
 
 .tabbed-set {
-  @mixin x-tabs;
-  @mixin x-tabs--custom-properties;
+  @mixin tabs;
+  @mixin tabs--custom-properties;
 }
 
 .tabbed-set > input {
-  @mixin x-tabs__toggle;
+  @mixin tabs__toggle;
 }
 .tabbed-set > .tabbed-content {
-  @mixin x-tabs__content--structure;
-  @mixin x-tabs__content--skin;
+  @mixin tabs__content--structure;
+  @mixin tabs__content--skin;
 }
 .tabbed-set > label {
-  @mixin x-tabs__tab--structure;
-  @mixin x-tabs__tab--skin;
+  @mixin tabs__tab--structure;
+  @mixin tabs__tab--skin;
 
   margin-bottom: unset; /* overwrite form.css which core-style.docs loads */
 }
 .tabbed-set > label:hover {
-  @mixin x-tabs__tab--hover;
+  @mixin tabs__tab--hover;
 }
 
 .tabbed-set > input:checked + label {
-  @mixin x-tabs__tab--active;
+  @mixin tabs__tab--active;
 }
 .tabbed-set > input:not(:checked) + label {
-  @mixin x-tabs__tab--not-active;
+  @mixin tabs__tab--not-active;
 }
 
 @media screen {
   .tabbed-set > input:checked + label + .tabbed-content {
-    @mixin x-tabs__content--active;
+    @mixin tabs__content--active;
   }
 }
 @media print {
   .tabbed-content {
-    @mixin x-tabs__content--force-active;
+    @mixin tabs__content--force-active;
   }
 }
 
@@ -46,7 +46,7 @@
 /* NOTE: Simple version shows outline even if browser would not do so for inputs
 
 .tabbed-set:focus-within {
-  @mixin x-tabs--focus-within;
+  @mixin tabs--focus-within;
 }
 
 */
@@ -55,13 +55,13 @@
     /* FAQ: The `:where(.tabbed-set > *)` prevents tabs focus UI
             when focusing on an element within the content */
     .tabbed-set:has(input:focus-visible:where(.tabbed-set > *)) {
-      @mixin x-tabs--focus-within;
+      @mixin tabs--focus-within;
     }
   }
 
   @supports not selector(:has(*)) {
     .tabbed-set:focus-within {
-      @mixin x-tabs--focus-within;
+      @mixin tabs--focus-within;
     }
   }
 }

--- a/src/lib/_imports/components/tacc-docs.css
+++ b/src/lib/_imports/components/tacc-docs.css
@@ -7,17 +7,17 @@
 }
 
 .rst-content > [role="navigation"] {
-  @mixin x-breadcrumbs;
-  @mixin x-breadcrumbs-major;
+  @mixin breadcrumbs;
+  @mixin breadcrumbs-major;
 }
 .rst-content > [role="navigation"] ul {
-  @mixin x-breadcrumbs__list;
-  @mixin x-breadcrumbs-major__list;
+  @mixin breadcrumbs__list;
+  @mixin breadcrumbs-major__list;
 }
 .rst-content > [role="navigation"] li {
-  @mixin x-breadcrumbs__list-item;
-  @mixin x-breadcrumbs-major__list-item;
+  @mixin breadcrumbs__list-item;
+  @mixin breadcrumbs-major__list-item;
 }
 .rst-content > [role="navigation"] li + li {
-  @mixin x-breadcrumbs__list-item--prefix-separator;
+  @mixin breadcrumbs__list-item--prefix-separator;
 }

--- a/src/lib/_imports/elements/mailto-link.css
+++ b/src/lib/_imports/elements/mailto-link.css
@@ -6,5 +6,5 @@
 @import url("../tools/x-mailto-text-replace.css");
 
 a[data-user][data-domain] {
-  @mixin x-mailto-text-replace;
+  @mixin mailto-text-replace;
 }

--- a/src/lib/_imports/elements/table.portal.css
+++ b/src/lib/_imports/elements/table.portal.css
@@ -2,5 +2,5 @@
 
 /* Assume portal tables always supports truncation */
 table {
-  @mixin s-truncated-table;
+  @mixin truncated-table;
 }

--- a/src/lib/_imports/objects/o-grid.css
+++ b/src/lib/_imports/objects/o-grid.css
@@ -31,7 +31,7 @@ Styleguide Objects.Grid
   gap: var(--gap);
 
   /* To always have equal height rows that match tallest content */
-  @mixin x-grid--layout-rows-equal-max-height;
+  @mixin grid--layout-rows-equal-max-height;
 }
 
 
@@ -67,7 +67,7 @@ Styleguide Objects.Grid
 /* Layout: Columns: Same Width, Preset Col. Count */
 
 .o-grid--col-auto-count {
-  @mixin x-grid--layout-cols-equal-set-count;
+  @mixin grid--layout-cols-equal-set-count;
 }
 @media (--x-narrow-and-below) { .o-grid--col-auto-count { --count: 1; } }
 @media (--x-narrow-to-narrow) { .o-grid--col-auto-count { --count: 2; } }
@@ -84,7 +84,7 @@ Styleguide Objects.Grid
 .o-grid--col-min-width {
   --width: 250px;
 
-  @mixin x-grid--layout-cols-equal-min-width;
+  @mixin grid--layout-cols-equal-min-width;
 }
 /* Prevent content overflow */
 /* FAQ: Excluding `img` because `.o-grid img` already sets this for images */
@@ -100,7 +100,7 @@ Styleguide Objects.Grid
 /* Layout: Content: Align Vert/Horz Center */
 
 .o-grid--center-align {
-  @mixin x-grid--content-align-center;
+  @mixin grid--content-align-center;
 }
 
 /* Layout: Content: Image Fills Cell/Container */

--- a/src/lib/_imports/objects/o-section.css
+++ b/src/lib/_imports/objects/o-section.css
@@ -141,10 +141,10 @@
 
   gap: var(--gap);
 }
-.o-section--layout-a { @mixin x-layout--a; }
-.o-section--layout-b { @mixin x-layout--b; }
-.o-section--layout-c { @mixin x-layout--c; }
-.o-section--layout-d { @mixin x-layout--d; }
+.o-section--layout-a { @mixin layout--a; }
+.o-section--layout-b { @mixin layout--b; }
+.o-section--layout-c { @mixin layout--c; }
+.o-section--layout-d { @mixin layout--d; }
 
 
 

--- a/src/lib/_imports/tools/x-breadcrumbs.css
+++ b/src/lib/_imports/tools/x-breadcrumbs.css
@@ -21,8 +21,8 @@ Styleguide Tools.Mixins.Breadcrumbs
 
 /* Container */
 
-@define-mixin x-breadcrumbs {}
-@define-mixin x-breadcrumbs-major {
+@define-mixin breadcrumbs {}
+@define-mixin breadcrumbs-major {
   padding-top: var(--global-space--above-breadcrumbs, 45px);
   margin-bottom: var(--global-space--under-breadcrumbs, 40px);
   font-size: var(--global-font-size--x-small, 1.4rem);
@@ -30,7 +30,7 @@ Styleguide Tools.Mixins.Breadcrumbs
 
 /* Content */
 
-@define-mixin x-breadcrumbs--list {
+@define-mixin breadcrumbs--list {
   /* To remove whitespace between items (but still allow text wrap) */
   display: flex;
   flex-wrap: wrap;
@@ -40,43 +40,43 @@ Styleguide Tools.Mixins.Breadcrumbs
   padding-left: unset;
   margin-top: unset;
 }
-@define-mixin x-breadcrumbs-major--list {
+@define-mixin breadcrumbs-major--list {
   font-weight: var(--medium, 500);
 }
 
-@define-mixin x-breadcrumbs__list {
-  @mixin x-breadcrumbs--list;
+@define-mixin breadcrumbs__list {
+  @mixin breadcrumbs--list;
 
   /* To undo default browser list (`<ol>`, `<ul>`) styles */
   margin-bottom: unset;
 }
-@define-mixin x-breadcrumbs-major__list {
-  @mixin x-breadcrumbs-major--list;
+@define-mixin breadcrumbs-major__list {
+  @mixin breadcrumbs-major--list;
 }
 
-@define-mixin x-breadcrumbs__list-item {
+@define-mixin breadcrumbs__list-item {
   /* To remove whitespace around text */
   display: inline-flex;
 }
-@define-mixin x-breadcrumbs-major__list-item {
+@define-mixin breadcrumbs-major__list-item {
   &:last-child {
     font-weight: var(--bold, 700);
   }
 }
 
-@define-mixin x-breadcrumbs__list-item--separator {
+@define-mixin breadcrumbs__list-item--separator {
   &::after,
   &::before {
     padding-inline: 0.5ch;
   }
 }
-@define-mixin x-breadcrumbs__list-item--suffix-separator {
-  @mixin x-breadcrumbs__list-item--separator;
+@define-mixin breadcrumbs__list-item--suffix-separator {
+  @mixin breadcrumbs__list-item--separator;
 
   &::after { content: ">"; }
 }
-@define-mixin x-breadcrumbs__list-item--prefix-separator {
-  @mixin x-breadcrumbs__list-item--separator;
+@define-mixin breadcrumbs__list-item--prefix-separator {
+  @mixin breadcrumbs__list-item--separator;
 
   &::before { content: ">"; }
 }

--- a/src/lib/_imports/tools/x-fake-border.css
+++ b/src/lib/_imports/tools/x-fake-border.css
@@ -5,9 +5,9 @@ Fake borders that have features unavailable to regular borders
 
 (custom property a.k.a. variable prefix `fb` stands for __f__ake __b__order)
 
-%x-fake-border--inset-horz-top - A top border that is not full width
-%x-fake-border--inset-horz-both - Borders top & bottom that are not full width
-%x-fake-border--inset-horz-bottom - A bottom border that is not full width
+%fake-border--inset-horz-top - A top border that is not full width
+%fake-border--inset-horz-both - Borders top & bottom that are not full width
+%fake-border--inset-horz-bottom - A bottom border that is not full width
 
 Styleguide Tools.Mixins.Overlay
 */
@@ -32,7 +32,7 @@ To avoid overwriting an existing `box-shadow`, use the public shadow variables:
 - `--fb--shadow-above: var(--YOUR-existing-shadow-ABOVE-fake-border)`
 - `--fb--shadow-below: var(--YOUR-existing-shadow-BELOW-fake-border)`
 */
-@define-mixin x-fake-border--inset-horz {
+@define-mixin fake-border--inset-horz {
   --fb--line-width: 0px; /* CAVEAT: add unit so `calc()` will not fail */
   --fb--line-color: transparent;
 
@@ -53,19 +53,19 @@ To avoid overwriting an existing `box-shadow`, use the public shadow variables:
     var(--fb),
     var(--fb--shadow-below, 0 0 transparent)
 }
-@define-mixin x-fake-border--inset-horz-top {
-  @mixin x-fake-border--inset-horz;
+@define-mixin fake-border--inset-horz-top {
+  @mixin fake-border--inset-horz;
 
   --fb--line: inset 0 calc( 1 * var(--fb--line-width)) var(--fb--line-color);
 }
-@define-mixin x-fake-border--inset-horz-both {
-  @mixin x-fake-border--inset-horz;
+@define-mixin fake-border--inset-horz-both {
+  @mixin fake-border--inset-horz;
 
   --fb--line: inset 0 calc( 1 * var(--fb--line-width)) var(--fb--line-color),
               inset 0 calc(-1 * var(--fb--line-width)) var(--fb--line-color);
 }
-@define-mixin x-fake-border--inset-horz-bottom {
-  @mixin x-fake-border--inset-horz;
+@define-mixin fake-border--inset-horz-bottom {
+  @mixin fake-border--inset-horz;
 
   --fb--line: inset 0 calc(-1 * var(--fb--line-width)) var(--fb--line-color);
 }

--- a/src/lib/_imports/tools/x-grid.css
+++ b/src/lib/_imports/tools/x-grid.css
@@ -4,17 +4,17 @@ Grid
 Snippets i.e. atomic abstractions of useful grid functionality.
 
 Caveats:
-- Do not combine two `x-grid--layout-rows-…` nor two `x-grid--layout-cols-…`.
+- Do not combine two `grid--layout-rows-…` nor two `grid--layout-cols-…`.
 
 Reference:
 - [A Complete Guide to Grid](https://css-tricks.com/snippets/css/complete-guide-grid/)
 
-x-grid--layout-rows-equal-max-height - Same height rows, match tallest content
-x-grid--layout-rows-equal-set-height - Same height rows, default var. height (custom properties: `--height`)
-x-grid--layout-cols-equal-set-count  - Same width columns, auto. column count (custom properties: `--count`)
-x-grid--layout-cols-equal-min-width  - Same width columns, default min. width (custom properties: `--width`)
-x-grid--layout-cols-equal-min-width-max-count  - Same width columns, default min. width, max. column count (custom properties: `--min-width`, `--max-cols`, `--row-height`, `--gap`)
-x-grid--content-align-center         - Align content vert.ly and horz.ly center
+grid--layout-rows-equal-max-height - Same height rows, match tallest content
+grid--layout-rows-equal-set-height - Same height rows, default var. height (custom properties: `--height`)
+grid--layout-cols-equal-set-count  - Same width columns, auto. column count (custom properties: `--count`)
+grid--layout-cols-equal-min-width  - Same width columns, default min. width (custom properties: `--width`)
+grid--layout-cols-equal-min-width-max-count  - Same width columns, default min. width, max. column count (custom properties: `--min-width`, `--max-cols`, `--row-height`, `--gap`)
+grid--content-align-center         - Align content vert.ly and horz.ly center
 
 Styleguide Tools.Mixins.Grid
 */
@@ -31,7 +31,7 @@ Styleguide Tools.Mixins.Grid
 
 /* Layout: Columns: Same Width, Preset Col. Count */
 
-@define-mixin x-grid--layout-cols-equal-set-count {
+@define-mixin grid--layout-cols-equal-set-count {
   /* --count */
 
   grid-template-columns: repeat(var(--count), auto);
@@ -39,12 +39,12 @@ Styleguide Tools.Mixins.Grid
 /* DEPRECATED */
 %x-grid--layout-cols-equal-set-count,
 .x-grid--layout-cols-equal-set-count {
-  @mixin x-grid--layout-cols-equal-set-count;
+  @mixin grid--layout-cols-equal-set-count;
 }
 
 /* Layout: Columns: Same Width, Preset Min. Width */
 
-@define-mixin x-grid--layout-cols-equal-min-width {
+@define-mixin grid--layout-cols-equal-min-width {
   /* --width */
 
   grid-template-columns: repeat(auto-fit, minmax(var(--width), 1fr));
@@ -52,7 +52,7 @@ Styleguide Tools.Mixins.Grid
 /* DEPRECATED */
 %x-grid--layout-cols-equal-min-width,
 .x-grid--layout-cols-equal-min-width {
-  @mixin x-grid--layout-cols-equal-min-width;
+  @mixin grid--layout-cols-equal-min-width;
 }
 /* Suggestion for User: Avoid content overflow */
 /*
@@ -64,9 +64,9 @@ Styleguide Tools.Mixins.Grid
 
 /* Layout: Columns: Same Width, Preset Col. Count, Preset Min. Width */
 /* https://css-tricks.com/an-auto-filling-css-grid-with-max-columns/ */
-/* TODO: Replace `x-grid--layout-cols-equal-min-width` with this */
+/* TODO: Replace `grid--layout-cols-equal-min-width` with this */
 
-@define-mixin x-grid--layout-cols-equal-min-width-max-count {
+@define-mixin grid--layout-cols-equal-min-width-max-count {
   /* input */
   --gap: var(--global-space--grid-gap);
   --max-cols: 7;
@@ -86,7 +86,7 @@ Styleguide Tools.Mixins.Grid
   grid-auto-rows: var(--row-height);
 }
 .x-grid--layout-cols-equal-min-width-max-count {
-  @mixin x-grid--layout-cols-equal-min-width-max-count;
+  @mixin grid--layout-cols-equal-min-width-max-count;
 }
 /* Suggestion for User: Avoid content overflow */
 /*
@@ -102,18 +102,18 @@ Styleguide Tools.Mixins.Grid
 
 /* Layout: Rows: Same Height (equal to height of tallest content in grid) */
 
-@define-mixin x-grid--layout-rows-equal-max-height {
+@define-mixin grid--layout-rows-equal-max-height {
   grid-auto-rows: 1fr;
 }
 /* DEPRECATED */
 %x-grid--layout-rows-equal-max-height,
 .x-grid--layout-rows-equal-max-height {
-  @mixin x-grid--layout-rows-equal-max-height;
+  @mixin grid--layout-rows-equal-max-height;
 }
 
 /* Layout: Rows: Same Height (equal to default, variable value) */
 
-@define-mixin x-grid--layout-rows-equal-set-height {
+@define-mixin grid--layout-rows-equal-set-height {
   /* --height */
 
   grid-auto-rows: var(--height);
@@ -121,7 +121,7 @@ Styleguide Tools.Mixins.Grid
 /* DEPRECATED */
 %x-grid--layout-rows-equal-set-height,
 .x-grid--layout-rows-equal-set-height {
-  @mixin x-grid--layout-rows-equal-set-height;
+  @mixin grid--layout-rows-equal-set-height;
 }
 
 
@@ -134,14 +134,14 @@ Styleguide Tools.Mixins.Grid
 
 /* Content: Align Vert/Horz Center */
 
-@define-mixin x-grid--content-align-center {
+@define-mixin grid--content-align-center {
   justify-items: center;
   align-items: center;
 }
 /* DEPRECATED */
 %x-grid--content-align-center,
 .x-grid--content-align-center {
-  @mixin x-grid--content-align-center;
+  @mixin grid--content-align-center;
 }
 
 
@@ -159,7 +159,7 @@ Styleguide Tools.Mixins.Grid
 }
 
 .user-block--modifier {
-  @mixin x-grid--...;
+  @mixin grid--...;
 }
 
 \/* Avoid leting content size (e.g. image) exceed cell size *\/

--- a/src/lib/_imports/tools/x-headings--cms.css
+++ b/src/lib/_imports/tools/x-headings--cms.css
@@ -9,7 +9,7 @@
 }
 
 @define-mixin heading-2 {
-    @mixin x-lead;
+    @mixin lead;
 }
 
 @define-mixin heading-3 {

--- a/src/lib/_imports/tools/x-layout.css
+++ b/src/lib/_imports/tools/x-layout.css
@@ -3,11 +3,11 @@ Layout
 
 Styles that allow re-usable layouts.
 
-x-layout--a - Widest: two even columns
-x-layout--b - Widest: one wide column & one narrow column
-x-layout--c - Widest: one narrow column & one wide column
-x-layout--d - Widest: three even columns
-x-layout--e - (deprecated) Always: multiple even rows
+layout--a - Widest: two even columns
+layout--b - Widest: one wide column & one narrow column
+layout--c - Widest: one narrow column & one wide column
+layout--d - Widest: three even columns
+layout--e - (deprecated) Always: multiple even rows
 
 Styleguide Tools.Mixins.Layout
 */
@@ -19,7 +19,7 @@ Styleguide Tools.Mixins.Layout
 
 /* A (two even columns) */
 
-@define-mixin x-layout--a {
+@define-mixin layout--a {
   display: grid;
 
   @media (--medium-and-below) {
@@ -32,12 +32,12 @@ Styleguide Tools.Mixins.Layout
 /* DEPRECATED */
 .x-layout--a,
 %x-layout--a {
-  @mixin x-layout--a;
+  @mixin layout--a;
 }
 
 /* B (one wide column & one narrow column) */
 
-@define-mixin x-layout--b {
+@define-mixin layout--b {
   display: grid;
 
   @media (--medium-and-below) {
@@ -50,12 +50,12 @@ Styleguide Tools.Mixins.Layout
 /* DEPRECATED */
 .x-layout--b,
 %x-layout--b {
-  @mixin x-layout--b;
+  @mixin layout--b;
 }
 
 /* C (one narrow column & one wide column) */
 
-@define-mixin x-layout--c {
+@define-mixin layout--c {
   display: grid;
 
   @media (--medium-and-below) {
@@ -68,12 +68,12 @@ Styleguide Tools.Mixins.Layout
 /* DEPRECATED */
 .x-layout--c,
 %x-layout--c {
-  @mixin x-layout--c;
+  @mixin layout--c;
 }
 
 /* D (three equal columns) */
 
-@define-mixin x-layout--d {
+@define-mixin layout--d {
   display: grid;
 
   @media (--x-narrow-and-below) {
@@ -89,18 +89,18 @@ Styleguide Tools.Mixins.Layout
 /* DEPRECATED */
 .x-layout--d,
 %x-layout--d {
-  @mixin x-layout--d;
+  @mixin layout--d;
 }
 
 
 /* Row-Based */
 
-@define-mixin x-layout--e {
+@define-mixin layout--e {
   display: flex;
   flex-direction: column;
 }
 /* DEPRECATED */
 .x-layout--e,
 %x-layout--e {
-  @mixin x-layout--e;
+  @mixin layout--e;
 }

--- a/src/lib/_imports/tools/x-lead.css
+++ b/src/lib/_imports/tools/x-lead.css
@@ -1,4 +1,4 @@
-@define-mixin x-lead {
+@define-mixin lead {
     color: var(--global-color-accent--secondary);
     font-size: var(--global-font-size--x-large);
     font-weight: var(--black);

--- a/src/lib/_imports/tools/x-lead.demo.css
+++ b/src/lib/_imports/tools/x-lead.demo.css
@@ -4,6 +4,6 @@
 /* HACK: Not in `x-lead/demo.css` because it is not processed */
 #demo {
   .x-lead {
-    @mixin x-lead;
+    @mixin lead;
   }
 }

--- a/src/lib/_imports/tools/x-mailto-text-replace.css
+++ b/src/lib/_imports/tools/x-mailto-text-replace.css
@@ -11,7 +11,7 @@ Styleguide Tools.Mixins.MailtoTextReplace
 /* To replace actual link text with generated link text */
 /* !!!: A user can not navigate to such a link with tab key */
 /* TODO: Deprecate this (or fix accessibility issue) */
-@define-mixin x-mailto-text-replace {
+@define-mixin mailto-text-replace {
     &:not(:--c-button) {
         /* FAQ: Using `display: none` would hide pseudo element text */
         visibility: hidden; /* to hide actual link text */

--- a/src/lib/_imports/tools/x-tabs.skin.css
+++ b/src/lib/_imports/tools/x-tabs.skin.css
@@ -1,17 +1,17 @@
-@define-mixin x-tabs--custom-properties {
+@define-mixin tabs--custom-properties {
   --buffer: 20px;
 }
 .x-tabs--custom-properties {
-  @mixin x-tabs--custom-properties;
+  @mixin tabs--custom-properties;
 }
-@define-mixin x-tabs--focus-within {
+@define-mixin tabs--focus-within {
   outline: 5px auto; /* to mimic browser outline */
 }
 .x-tabs--focus-within {
-  @mixin x-tabs--focus-within;
+  @mixin tabs--focus-within;
 }
 
-@define-mixin x-tabs__tab--skin {
+@define-mixin tabs__tab--skin {
   padding-block: 1.25em 0.75em;
   padding-inline: 0.875em;
   margin-inline: var(--buffer);
@@ -29,29 +29,29 @@
   }
 }
 .x-tabs__tab {
-  @mixin x-tabs__tab--skin;
+  @mixin tabs__tab--skin;
 }
-@define-mixin x-tabs__tab--hover {
+@define-mixin tabs__tab--hover {
   border-color: var(--global-color-primary--dark);
 }
 .x-tabs__tab--hover {
-  @mixin x-tabs__tab--hover;
+  @mixin tabs__tab--hover;
 }
-@define-mixin x-tabs__tab--not-active {
+@define-mixin tabs__tab--not-active {
   color: var(--global-color-primary--dark);
 }
 .x-tabs__tab--not-active {
-  @mixin x-tabs__tab--not-active;
+  @mixin tabs__tab--not-active;
 }
-@define-mixin x-tabs__tab--active {
+@define-mixin tabs__tab--active {
   color: var(--global-color-accent--light);
   border-color: var(--global-color-accent--light);
 }
 .x-tabs__tab--active {
-  @mixin x-tabs__tab--active;
+  @mixin tabs__tab--active;
 }
 
-@define-mixin x-tabs__content--skin {
+@define-mixin tabs__content--skin {
   padding-inline: var(--buffer);
 
   border-top: var(--global-border-width--normal) solid var(--global-color-primary--dark);
@@ -64,5 +64,5 @@
   }
 }
 .x-tabs__content {
-  @mixin x-tabs__content--skin;
+  @mixin tabs__content--skin;
 }

--- a/src/lib/_imports/tools/x-tabs.structure.css
+++ b/src/lib/_imports/tools/x-tabs.structure.css
@@ -1,46 +1,46 @@
-@define-mixin x-tabs {
+@define-mixin tabs {
   position: relative;
   display: flex;
   flex-wrap: wrap;
 }
 .x-tabs {
-  @mixin x-tabs;
+  @mixin tabs;
 }
 
-@define-mixin x-tabs__toggle {
+@define-mixin tabs__toggle {
   /* FAQ: If `display: none` were used, keyboard accessibility would break */
   position: absolute;
   opacity: 0;
 }
 .x-tabs__toggle {
-  @mixin x-tabs__toggle;
+  @mixin tabs__toggle;
 }
 
-@define-mixin x-tabs__tab--structure {
+@define-mixin tabs__tab--structure {
   white-space: nowrap;
   cursor: pointer;
 }
 .x-tabs__tab {
-  @mixin x-tabs__tab--structure;
+  @mixin tabs__tab--structure;
 }
 
-@define-mixin x-tabs__content--structure {
+@define-mixin tabs__content--structure {
   width: 100%;
   display: none;
 }
 .x-tabs__content {
-  @mixin x-tabs__content--structure;
+  @mixin tabs__content--structure;
 }
-@define-mixin x-tabs__content--active {
+@define-mixin tabs__content--active {
   order: 99;
   display: block;
 }
 .x-tabs__content--active {
-  @mixin x-tabs__content--active;
+  @mixin tabs__content--active;
 }
-@define-mixin x-tabs__content--force-active {
+@define-mixin tabs__content--force-active {
   display: contents;
 }
 .x-tabs__content--force-active {
-  @mixin x-tabs__content--force-active;
+  @mixin tabs__content--force-active;
 }

--- a/src/lib/_imports/trumps/s-article-list.css
+++ b/src/lib/_imports/trumps/s-article-list.css
@@ -191,11 +191,11 @@ Styleguide Trumps.Scopes.ArticleList
 
 /* Modifiers: Layout */
 
-.s-article-list--layout-a { @mixin x-layout--a; }
-.s-article-list--layout-b { @mixin x-layout--b; }
-.s-article-list--layout-c { @mixin x-layout--c; }
-.s-article-list--layout-d { @mixin x-layout--d; }
-.s-article-list--layout-e { @mixin x-layout--e; }
+.s-article-list--layout-a { @mixin layout--a; }
+.s-article-list--layout-b { @mixin layout--b; }
+.s-article-list--layout-c { @mixin layout--c; }
+.s-article-list--layout-d { @mixin layout--d; }
+.s-article-list--layout-e { @mixin layout--e; }
 
 /* Modifiers: Layout: Column-Based */
 

--- a/src/lib/_imports/trumps/s-breadcrumbs.css
+++ b/src/lib/_imports/trumps/s-breadcrumbs.css
@@ -3,35 +3,35 @@
 .s-breadcrumbs:where(nav),
 .s-breadcrumbs:where(ol),
 .s-breadcrumbs-via-ul {
-  @mixin x-breadcrumbs;
+  @mixin breadcrumbs;
 }
 .s-breadcrumbs:where(nav),
 .s-breadcrumbs-via-ul {
-  @mixin x-breadcrumbs-major;
+  @mixin breadcrumbs-major;
 }
 
 .s-breadcrumbs:where(nav) ol,
 .s-breadcrumbs:where(ol),
 .s-breadcrumbs-via-ul ul {
-  @mixin x-breadcrumbs__list;
+  @mixin breadcrumbs__list;
 }
 .s-breadcrumbs:where(nav) ol,
 .s-breadcrumbs-via-ul ul {
-  @mixin x-breadcrumbs-major__list;
+  @mixin breadcrumbs-major__list;
 }
 
 .s-breadcrumbs:where(nav) ol li,
 .s-breadcrumbs:where(ol) li,
 .s-breadcrumbs-via-ul ul li {
-  @mixin x-breadcrumbs__list-item;
+  @mixin breadcrumbs__list-item;
 }
 .s-breadcrumbs:where(nav) ol li,
 .s-breadcrumbs-via-ul ul li {
-  @mixin x-breadcrumbs-major__list-item;
+  @mixin breadcrumbs-major__list-item;
 }
 
 .s-breadcrumbs:where(nav) ol li + li,
 .s-breadcrumbs:where(ol) li + li,
 .s-breadcrumbs-via-ul ul li + li {
-  @mixin x-breadcrumbs__list-item--prefix-separator;
+  @mixin breadcrumbs__list-item--prefix-separator;
 }

--- a/src/lib/_imports/trumps/s-image-grid.css
+++ b/src/lib/_imports/trumps/s-image-grid.css
@@ -5,7 +5,7 @@
 /* Grid Layout */
 
 .s-image-grid {
-  @mixin x-grid--layout-cols-equal-min-width-max-count;
+  @mixin grid--layout-cols-equal-min-width-max-count;
 
   /*
   --gap: var(--global-space--grid-gap);

--- a/src/lib/_imports/trumps/s-lead.css
+++ b/src/lib/_imports/trumps/s-lead.css
@@ -1,5 +1,5 @@
 @import url("../tools/x-lead.css");
 
 .s-lead {
-    @mixin x-lead;
+    @mixin lead;
 }

--- a/src/lib/_imports/trumps/s-truncated-table.css
+++ b/src/lib/_imports/trumps/s-truncated-table.css
@@ -1,11 +1,11 @@
 @import url("../tools/x-truncate.css");
 
 /* To truncate paragraphs in specific tables */
-@define-mixin s-truncated-table {
+@define-mixin truncated-table {
   & p {
     @mixin truncate--many-lines;
   }
 }
 .s-truncated-table {
-  @mixin s-truncated-table;
+  @mixin truncated-table;
 }

--- a/src/lib/_imports/trumps/u-mailto-text-replace.css
+++ b/src/lib/_imports/trumps/u-mailto-text-replace.css
@@ -1,7 +1,7 @@
-/* A utility class of `x-mailto-text-replace` */
+/* A utility class of `mailto-text-replace` */
 
 @import url("../tools/x-mailto-text-replace.css");
 
 .u-mailto-text-replace[data-user][data-domain] {
-    @mixin x-mailto-text-replace;
+    @mixin mailto-text-replace;
 }


### PR DESCRIPTION
## Overview

Several mixins carried over an `x-`/`c-`/`s-` prefix from the class they were extracted from; a mixin's name should be its base name, with the prefix reserved for the class that demos/consumes it.

## Related

- part of #340

## Changes

- **renamed** `x-tabs`, `x-grid--*`, `x-layout--*`, `x-fake-border--*`, `x-breadcrumbs*`, `x-lead`, `x-mailto-text-replace`, `c-nav--piped--*`, and `s-truncated-table` mixins (and all call sites) to drop the prefix
- **left** every `.x-…`/`.c-…`/`.s-…` class untouched, including the deprecated `.x-grid--*`/`.x-layout--*` back-compat aliases
- **rebuilt** `dist/`

## Testing

1. `npm run build:css`
2. Confirm `dist/` output is unchanged

## UI

No UI change — mixin rename only; `dist/` output is byte-for-byte identical to before.